### PR TITLE
remove bug re-order workflow

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -764,26 +764,6 @@ class SalesOrder(SellingController):
 			voucher_type=self.doctype, voucher_no=self.name, sre_list=sre_list, notify=notify
 		)
 
-	def handle_re_order(self):
-		# allow to link to cancelled documents
-		self.flags.ignore_links = True
-		if isinstance(self.haravan_ref_order_id, int):
-			# find sales order by haravan_ref_order_id
-			ref_sales_order = frappe.get_last_doc("Sales Order", filters=[["haravan_order_id", "=", self.haravan_ref_order_id]])
-			if not ref_sales_order or ref_sales_order.name == self.name:
-				return
-			# link to the reference sales order
-			self.append("ref_sales_orders", {"sales_order": ref_sales_order.name})
-
-			# update allocation
-			if len(ref_sales_order.sales_team) > 0:
-				self.sales_team = []  # Clear existing sales team entries
-				for team in ref_sales_order.sales_team:
-					self.append("sales_team", {
-						"sales_person": team.sales_person,
-						"allocated_percentage": team.allocated_percentage
-					})
-
 	def handle_order_cancellation(self):
 		"""If order from Haravan is cancelled, cancel the current order too"""
 
@@ -800,7 +780,6 @@ class SalesOrder(SellingController):
 		self.handle_order_cancellation()
 		
 	def before_insert(self):
-		self.handle_re_order()
 		self.handle_order_cancellation()
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:


### PR DESCRIPTION
### **User description**
handle_re_order has bug which prevent insert sales order. Temporarily remove from main branch.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove the `handle_re_order` workflow due to a bug.

- Prevent execution of re-order logic during sales order insertion.

- Ensure only order cancellation logic runs before insert/save.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Remove buggy re-order logic from Sales Order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<li>Deleted the <code>handle_re_order</code> method entirely.<br> <li> Removed call to <code>handle_re_order</code> from <code>before_insert</code>.<br> <li> Ensured only cancellation logic is executed before insert/save.


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/17/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+0/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>