### PR TITLE
Change Customer Haravan ID field type for integration

### DIFF
--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -839,7 +839,7 @@
   },
   {
    "fieldname": "haravan_id",
-   "fieldtype": "Int",
+   "fieldtype": "Data",
    "label": "Haravan ID",
    "read_only": 1
   },
@@ -972,7 +972,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-05-22 21:19:23.526654",
+ "modified": "2025-05-26 13:41:06.975779",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -70,7 +70,7 @@ class Customer(TransactionBase):
 		email_id: DF.ReadOnly | None
 		first_source: DF.Link | None
 		gender: DF.Link | None
-		haravan_id: DF.Int
+		haravan_id: DF.Data | None
 		image: DF.AttachImage | None
 		industry: DF.Link | None
 		invoice_type: DF.Literal["Individual", "Company"]


### PR DESCRIPTION
### **User description**
Enhace Haravan ID field type for integration


___

### **PR Type**
Enhancement


___

### **Description**
- Changed `haravan_id` field type from Int to Data

- Updated both Python model and JSON schema for consistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.py</strong><dd><code>Update haravan_id type in Customer Python model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.py

<li>Changed the type of <code>haravan_id</code> from <code>DF.Int</code> to <code>DF.Data | None</code><br> <li> Ensures the Python model matches the new intended field type


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/22/files#diff-6c864e7eb264f62092ce56e22731b2736152c26b9c8961d5039c8cb8b9361f2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>customer.json</strong><dd><code>Update haravan_id fieldtype in Customer JSON schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.json

<li>Changed <code>haravan_id</code> fieldtype from <code>Int</code> to <code>Data</code><br> <li> Updated the <code>modified</code> timestamp for the schema<br> <li> Maintained read-only status for the field


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/22/files#diff-e851c9f6c12204fced775db0f626fa7ccb65899189362a9312d8b94bc59d160d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>