### PR TITLE
add Real Order Date to sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -27,6 +27,7 @@
   "customer_name",
   "order_number",
   "transaction_date",
+  "real_order_date",
   "column_break_dqxa",
   "financial_status",
   "fulfillment_status",
@@ -1919,13 +1920,18 @@
    "fieldtype": "Table MultiSelect",
    "label": "Product Category",
    "options": "Sales Order Product Category"
+  },
+  {
+   "fieldname": "real_order_date",
+   "fieldtype": "Date",
+   "label": "Real Order Date"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-26 13:17:48.479379",
+ "modified": "2025-05-30 10:38:13.386251",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -155,6 +155,7 @@ class SalesOrder(SellingController):
 		product_categories: DF.TableMultiSelect[SalesOrderProductCategory]
 		project: DF.Link | None
 		promotions: DF.TableMultiSelect[SalesOrderPromotion]
+		real_order_date: DF.Date | None
 		ref_sales_orders: DF.Table[SalesOrderReference]
 		represents_company: DF.Link | None
 		reserve_stock: DF.Check


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added `Real Order Date` field to Sales Order doctype

- Updated Python and JSON schema to support new field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Add real_order_date field to SalesOrder Python class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<li>Introduced <code>real_order_date</code> as an optional date field in SalesOrder <br>class.<br> <li> Extended the SalesOrder data model to include the new field.


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/27/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales_order.json</strong><dd><code>Add Real Order Date field to Sales Order schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.json

<li>Added <code>real_order_date</code> to the list of fields in the Sales Order <br>doctype.<br> <li> Defined <code>real_order_date</code> as a Date field with label "Real Order Date".<br> <li> Updated the modification timestamp and metadata.


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/27/files#diff-60468f41a3b442dc6134bd9661f3225db58882f960aac83ef55325cf7f7b980e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>