### PR TITLE
fix: bug ui and parse data

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -37,7 +37,7 @@
   "request_type",
   "lead_name",
   "lead_received_date",
-  "customer_demand_section",
+  "qualified_information_section",
   "purpose_lead",
   "expected_delivery_date",
   "column_break_ugod",

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -355,7 +355,7 @@ class Lead(SellingController, CRMNote):
 				"pancake_updated_at": parsed_pancake_data.get("updated_at") if parsed_pancake_data and parsed_pancake_data.get("updated_at") else None,
 				"pancake_page_id": parsed_pancake_data.get("page_id") if parsed_pancake_data and parsed_pancake_data.get("page_id") else None,
 				"can_inbox": parsed_pancake_data.get("can_inbox") if parsed_pancake_data and parsed_pancake_data.get("can_inbox") else 0,
-				"last_message_time" :  parsed_pancake_data.get("latest_message_at", None)
+				"last_message_time" :  parsed_pancake_data.get("latest_message_at", None) if parsed_pancake_data else None
 			}
 		)
 


### PR DESCRIPTION
### **User description**
PR fix bug UI and parse data


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes bug in parsing `latest_message_at` from `parsed_pancake_data`

- Updates lead JSON to use `qualified_information_section` instead of `customer_demand_section`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.py</strong><dd><code>Fix bug in parsing and assigning last message time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.py

<li>Corrects logic for setting <code>last_message_time</code> to handle missing <br><code>parsed_pancake_data</code><br> <li> Prevents errors when <code>parsed_pancake_data</code> is None


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/29/files#diff-64a0af8f42900682b438917e3168d6ccc911231563f66c68fd21a532f237ccd4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lead.json</strong><dd><code>Update lead JSON to use qualified information section</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.json

<li>Replaces <code>customer_demand_section</code> with <code>qualified_information_section</code> in <br>lead fields<br> <li> Updates field order for lead document definition


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/29/files#diff-e5dfba1fe37968a6bf45ca378c9ce7339595da50b0c3bb68524a8c961314d097">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>