### PR TITLE
fix: remove status in list view

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -40,15 +40,15 @@ frappe.listview_settings["Sales Order"] = {
 		const resultEl = document.querySelector('.result');
 		if (resultEl) {
 			const observer = new MutationObserver(function (mutationsList, observer) {
-      // Order Number
-      for (let i = 0; i < listview.data.length; i++) {
-        if (listview.data[i].cancelled_status === "Uncancelled") {
+				// Order Number
+				for (let i = 0; i < listview.data.length; i++) {
+					if (listview.data[i].cancelled_status === "Uncancelled") {
 						$(`.result .list-row-container:nth-child(${i + 3}) .list-row-col:nth-child(1) a`).css("color", "rgb(35, 98, 235)");
 					} else {
 						$(`.result .list-row-container:nth-child(${i + 3}) .list-row-col:nth-child(1) a`).css("color", "rgb(219, 48, 48)");
 					}
 				}
-				
+
 				$('span[data-filter]').removeAttr('class').addClass('indicator-pill').addClass('no-indicator-dot').addClass('filterable');
 				// Cancelled Status
 				$('span[data-filter="cancelled_status,=,Uncancelled"]').addClass('green');
@@ -63,5 +63,7 @@ frappe.listview_settings["Sales Order"] = {
 			});
 			observer.observe(resultEl, { childList: true, subtree: true });
 		}
+		// Remove the title status
+		$(".page-head-content .title-area span").removeAttr('style').text("");
 	}
 };


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Bug fix


___

### **Description**
- Removes status display from Sales Order list view title.

- Ensures status text is cleared from the title area.

- Maintains color coding for order and status indicators.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order_list.js</strong><dd><code>Remove and clear status from Sales Order list view title</code>&nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order_list.js

<li>Added code to remove and clear the status text in the page title area.<br> <li> Ensured no style is applied to the status span in the title.<br> <li> Retained existing logic for color coding and indicator updates.


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/33/files#diff-40eb5df81a395f1ebff57d1879b6f5ab9f789396ce36446b1923ff571dca8dc5">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>