### PR TITLE
chore: qualidfied lead date

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -739,7 +739,8 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Lead Stage",
-   "options": "Lead\nQualified Lead\nOpportunity\nCustomer"
+   "options": "Lead\nQualified Lead\nOpportunity\nCustomer",
+   "read_only": 1
   },
   {
    "fieldname": "province",
@@ -751,7 +752,7 @@
    "fieldname": "qualified_lead_date",
    "fieldtype": "Datetime",
    "hidden": 1,
-   "label": "Qualified Date Date"
+   "label": "Qualified Lead Date"
   },
   {
    "fieldname": "region",
@@ -764,7 +765,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2025-06-04 09:31:11.855702",
+ "modified": "2025-06-06 10:22:20.134879",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",


### PR DESCRIPTION
### **User description**
Update label and does not allow edit manual


___

### **PR Type**
Enhancement


___

### **Description**
- Made `lead_stage` field read-only to prevent manual edits

- Corrected label for `qualified_lead_date` field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.json</strong><dd><code>Make `lead_stage` read-only and correct field label typo</code>&nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.json

<li>Added <code>read_only: 1</code> to <code>lead_stage</code> field to prevent editing<br> <li> Fixed label typo for <code>qualified_lead_date</code> to "Qualified Lead Date"<br> <li> Updated <code>modified</code> timestamp to reflect changes


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/35/files#diff-e5dfba1fe37968a6bf45ca378c9ce7339595da50b0c3bb68524a8c961314d097">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>