### PR TITLE
Feature: Add Lead Source Information to Lead

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -37,6 +37,8 @@
   "request_type",
   "lead_name",
   "lead_received_date",
+  "lead_source_name",
+  "lead_source_platform",
   "qualified_information_section",
   "purpose_lead",
   "expected_delivery_date",
@@ -767,13 +769,29 @@
    "fieldtype": "Datetime",
    "hidden": 1,
    "label": "First Reach At"
+  },
+  {
+   "fetch_from": "source.source_name",
+   "fieldname": "lead_source_name",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Lead Source Name",
+   "options": "Lead"
+  },
+  {
+   "fetch_from": "source.pancake_platform",
+   "fieldname": "lead_source_platform",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Lead Source Platform",
+   "options": "Lead"
   }
  ],
  "icon": "fa fa-user",
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2025-06-13 09:11:48.906859",
+ "modified": "2025-06-13 01:26:39.540075",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -62,6 +62,8 @@ class Lead(SellingController, CRMNote):
 		lead_name: DF.Data | None
 		lead_owner: DF.Link | None
 		lead_received_date: DF.Datetime | None
+		lead_source_name: DF.Link | None
+		lead_source_platform: DF.Link | None
 		lead_stage: DF.Literal["Lead", "Qualified Lead", "Opportunity", "Customer"]
 		market_segment: DF.Link | None
 		middle_name: DF.Data | None


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
• Add lead source name and platform fields to Lead doctype
• Implement fetch functionality from source field
• Configure hidden fields for lead source tracking


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.py</strong><dd><code>Add lead source field definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.py

• Added <code>lead_source_name</code> and <code>lead_source_platform</code> field definitions<br> • <br>Both fields configured as Link type with None default values


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/46/files#diff-64a0af8f42900682b438917e3168d6ccc911231563f66c68fd21a532f237ccd4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lead.json</strong><dd><code>Configure lead source fields in doctype</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.json

• Added two new fields to Lead doctype configuration<br> • Configured <br>fetch functionality from <code>source.source_name</code> and <br><code>source.pancake_platform</code><br> • Set fields as hidden with Link fieldtype <br>pointing to Lead options<br> • Updated modification timestamp


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/46/files#diff-e5dfba1fe37968a6bf45ca378c9ce7339595da50b0c3bb68524a8c961314d097">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>