### PR TITLE
Fix/Adjust qualified processing

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -449,7 +449,7 @@
    "fieldname": "qualification_status",
    "fieldtype": "Select",
    "label": "Qualification Status",
-   "options": "Unqualified\nIn Process\nQualified"
+   "options": "Unqualified\nQualified"
   },
   {
    "fieldname": "address_section",
@@ -790,7 +790,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2025-07-08 06:53:39.938611",
+ "modified": "2025-07-08 08:44:32.750431",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",

--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -39,6 +39,11 @@
   "lead_received_date",
   "lead_source_name",
   "lead_source_platform",
+  "qualification_tab",
+  "qualification_status",
+  "column_break_64",
+  "qualified_by",
+  "qualified_on",
   "qualified_information_section",
   "purpose_lead",
   "expected_delivery_date",
@@ -101,11 +106,6 @@
   "whatsapp_no",
   "column_break_16",
   "phone_ext",
-  "qualification_tab",
-  "qualification_status",
-  "column_break_64",
-  "qualified_by",
-  "qualified_on",
   "note_tab",
   "notes_html",
   "notes",
@@ -418,10 +418,8 @@
    "label": "Phone Ext."
   },
   {
-   "collapsible": 1,
    "fieldname": "qualification_tab",
    "fieldtype": "Section Break",
-   "hidden": 1,
    "label": "Qualification"
   },
   {
@@ -444,7 +442,7 @@
   },
   {
    "fieldname": "qualified_on",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Qualified on"
   },
   {
@@ -792,7 +790,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2025-07-03 08:25:49.026080",
+ "modified": "2025-07-08 06:53:39.938611",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -80,7 +80,7 @@ class Lead(SellingController, CRMNote):
 		preferred_product_type: DF.TableMultiSelect[LeadProductItem]
 		province: DF.Link | None
 		purpose_lead: DF.Link | None
-		qualification_status: DF.Literal["Unqualified", "In Process", "Qualified"]
+		qualification_status: DF.Literal["Unqualified", "Qualified"]
 		qualified_by: DF.Link | None
 		qualified_lead_date: DF.Datetime | None
 		qualified_on: DF.Datetime | None
@@ -644,12 +644,8 @@ class Lead(SellingController, CRMNote):
 		"""
 		if self.phone and self.province:
 			return "Qualified"
-		
-		# If already qualified, don't change back automatically
-		if self.qualification_status == "Qualified":
-			return "Qualified"
 			
-		return "Unqualified"
+		return self.qualification_status
 
 @frappe.whitelist()
 def make_customer(source_name, target_doc=None):

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -83,7 +83,7 @@ class Lead(SellingController, CRMNote):
 		qualification_status: DF.Literal["Unqualified", "In Process", "Qualified"]
 		qualified_by: DF.Link | None
 		qualified_lead_date: DF.Datetime | None
-		qualified_on: DF.Date | None
+		qualified_on: DF.Datetime | None
 		region: DF.Link | None
 		request_type: DF.Literal["Product Enquiry", "Request for Information", "Suggestions", "Other"]
 		salutation: DF.Link | None
@@ -156,6 +156,7 @@ class Lead(SellingController, CRMNote):
 		
 	def before_save(self):
 		self.update_lead_stage()
+		self.update_qualification_status() 
 		self.fetch_region_from_province()
 		self.update_first_reach_at()
 		self.upsert_lead_source()
@@ -171,6 +172,34 @@ class Lead(SellingController, CRMNote):
 			and  not self.qualified_lead_date \
 			and self.lead_stage != "Lead" :
 			self.qualified_lead_date = frappe.utils.now_datetime()
+	def update_qualification_status(self):
+		"""
+		Update qualification status based on phone and province
+		Only auto-qualifies when conditions are met, never auto-disqualifies
+		Also set qualified_by and qualified_on when manually changed to Qualified
+		"""
+		# User manually changed to Qualified
+		if self.has_value_changed("qualification_status") and self.qualification_status == "Qualified":
+			if not self.qualified_by:
+				self.qualified_by = frappe.session.user
+			self.qualified_on = frappe.utils.now_datetime()
+			return  
+		
+		
+		new_qualification_status = self.get_qualification_status()
+		
+		# Auto-qualification logic based on phone and province
+		if (new_qualification_status == "Qualified" and self.qualification_status != "Qualified") or \
+		   (self.qualification_status != "Qualified"):
+			
+			old_status = self.qualification_status
+			self.qualification_status = new_qualification_status
+			
+			# Set qualified_by and qualified_on when moving to Qualified
+			if self.qualification_status == "Qualified" and old_status != "Qualified":
+				if not self.qualified_by:
+					self.qualified_by = frappe.session.user
+				self.qualified_on = frappe.utils.now_datetime()
 		
 	def update_lead_owner(self, pancake_user_id:str | None):
 		"""
@@ -608,6 +637,19 @@ class Lead(SellingController, CRMNote):
 		# return "Opportunity"
 
 		return "Qualified Lead"
+	def get_qualification_status(self):
+		"""
+		Determine qualification status based on phone and province
+		Only auto-qualifies, never auto-disqualifies
+		"""
+		if self.phone and self.province:
+			return "Qualified"
+		
+		# If already qualified, don't change back automatically
+		if self.qualification_status == "Qualified":
+			return "Qualified"
+			
+		return "Unqualified"
 
 @frappe.whitelist()
 def make_customer(source_name, target_doc=None):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -413,3 +413,7 @@ erpnext.seeds.item_group.create_default_lead_demand
 erpnext.seeds.lead.update_region
 # 2025-06-17
 erpnext.seeds.lead.backfill_qualified_lead_date
+# 2025-07-08
+erpnext.seeds.lead.backfill_qualification_status
+# 2025-07-08
+erpnext.seeds.lead.backfill_qualified_on

--- a/erpnext/seeds/lead/backfill_qualification_status.py
+++ b/erpnext/seeds/lead/backfill_qualification_status.py
@@ -5,7 +5,7 @@ def execute():
     try: 
         frappe.db.sql("""
             UPDATE `tabLead`
-            SET qualification_status = 'Qualified', qualified_by = 'Administrator'
+            SET qualification_status = 'Qualified', qualified_by = 'tech@jemmia.vn'
             WHERE qualified_lead_date IS NOT NULL
             """)
     except Exception:
@@ -13,4 +13,3 @@ def execute():
         print("Failed to update qualified lead date")
         return
     frappe.db.commit()
-    

--- a/erpnext/seeds/lead/backfill_qualification_status.py
+++ b/erpnext/seeds/lead/backfill_qualification_status.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+    try: 
+        frappe.db.sql("""
+            UPDATE `tabLead`
+            SET qualification_status = 'Qualified', qualified_by = 'Administrator'
+            WHERE qualified_lead_date IS NOT NULL
+            """)
+    except Exception:
+        frappe.db.rollback()
+        print("Failed to update qualified lead date")
+        return
+    frappe.db.commit()
+    

--- a/erpnext/seeds/lead/backfill_qualified_on.py
+++ b/erpnext/seeds/lead/backfill_qualified_on.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+    try: 
+        frappe.db.sql("""
+            UPDATE `tabLead`
+            SET qualified_on = qualified_lead_date
+            """)
+    except Exception:
+        frappe.db.rollback()
+        print("Failed to update qualified lead date")
+        return
+    frappe.db.commit()


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced lead qualification processing with automatic status updates

- Added qualification tracking with user and timestamp fields

- Created database migration scripts for existing leads

- Improved UI by making qualification tab visible and reorganized


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Lead Data"] --> B["Auto-qualification Logic"]
  B --> C["Phone & Province Check"]
  C --> D["Update Qualification Status"]
  D --> E["Set Qualified By & Date"]
  F["Manual Status Change"] --> E
  G["Migration Scripts"] --> H["Backfill Existing Data"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.py</strong><dd><code>Enhanced lead qualification processing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.py

<li>Changed <code>qualified_on</code> field type from Date to Datetime<br> <li> Added <code>update_qualification_status()</code> method with auto-qualification <br>logic<br> <li> Enhanced qualification processing based on phone and province fields<br> <li> Added automatic setting of <code>qualified_by</code> and <code>qualified_on</code> fields


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/88/files#diff-64a0af8f42900682b438917e3168d6ccc911231563f66c68fd21a532f237ccd4">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backfill_qualification_status.py</strong><dd><code>Migration script for qualification status backfill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/seeds/lead/backfill_qualification_status.py

<li>Created migration script to update existing leads<br> <li> Sets qualification_status to 'Qualified' for leads with <br>qualified_lead_date<br> <li> Sets qualified_by to 'Administrator' for migrated records


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/88/files#diff-68db44a9cffa18b48c602d11490c17568f13c50d27d36f9a36cd2c75fd4c6030">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backfill_qualified_on.py</strong><dd><code>Migration script for qualified_on field backfill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/seeds/lead/backfill_qualified_on.py

<li>Created migration script to populate qualified_on field<br> <li> Copies qualified_lead_date values to qualified_on field<br> <li> Handles data migration for existing leads


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/88/files#diff-d0e6d9da903b15fbcad9cae8f28041f95efaa3a60aa6415a98671e4d30875779">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.json</strong><dd><code>Updated lead form layout and field types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.json

<li>Moved qualification fields to top of form layout<br> <li> Changed qualified_on field type from Date to Datetime<br> <li> Made qualification tab visible (removed hidden property)<br> <li> Removed collapsible property from qualification section


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/88/files#diff-e5dfba1fe37968a6bf45ca378c9ce7339595da50b0c3bb68524a8c961314d097">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>