### PR TITLE
Fix(Lead): Ignore permission for AI update

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -507,7 +507,7 @@ class Lead(SellingController, CRMNote):
 					contact_name = linked_contacts_data[0].get('parent', None)
 					contact = frappe.get_doc("Contact", contact_name)
 					self.source = contact.source
-					self.save()
+					self.save(ignore_permissions=True)
 
 		except Exception as e:
 			print(f"Error set_first_lead_source {e}")

--- a/erpnext/crm/doctype/lead/lead_methods.py
+++ b/erpnext/crm/doctype/lead/lead_methods.py
@@ -237,7 +237,7 @@ def update_lead_by_batch(docs):
 				doc["lead_name"] = existing_doc.lead_name
 
 			existing_doc.update(doc)
-			existing_doc.save()
+			existing_doc.save(ignore_permissions=True)
 			frappe.db.commit()
 			
 			contact = None
@@ -405,7 +405,7 @@ def update_lead_from_summary(data):
 							"product_type": product.name
 						})
 
-			lead.save()
+			lead.save(ignore_permissions=True)
 			break
 		except Exception as e:
 			if e is frappe.TimestampMismatchError:


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Bug fix


___

### **Description**
- Add `ignore_permissions=True` to Lead save operations

- Enable AI updates to bypass permission checks

- Fix permission errors in automated Lead processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AI["AI Update Process"] --> Lead["Lead Document"]
  Lead --> Save["save(ignore_permissions=True)"]
  Save --> Success["Bypass Permission Checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.py</strong><dd><code>Ignore permissions in lead source setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.py

<ul><li>Add <code>ignore_permissions=True</code> parameter to <code>save()</code> call in <br><code>set_first_lead_source</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/146/files#diff-64a0af8f42900682b438917e3168d6ccc911231563f66c68fd21a532f237ccd4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lead_methods.py</strong><dd><code>Ignore permissions in batch and summary updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead_methods.py

<ul><li>Add <code>ignore_permissions=True</code> to <code>save()</code> in <code>update_lead_by_batch</code> function<br> <li> Add <code>ignore_permissions=True</code> to <code>save()</code> in <code>update_lead_from_summary</code> <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/146/files#diff-bb9e795b0f2b4cbb93d5dbcf3ee4fafe091c8b84e1f121273fec7d9d15e291b3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

