### PR TITLE
fix(sales_team): add precision to contribution percentage field

### DIFF
--- a/erpnext/selling/doctype/sales_team/sales_team.json
+++ b/erpnext/selling/doctype/sales_team/sales_team.json
@@ -47,6 +47,7 @@
    "label": "Contribution (%)",
    "oldfieldname": "allocated_percentage",
    "oldfieldtype": "Currency",
+   "precision": "5",
    "print_width": "100px",
    "width": "100px"
   },
@@ -85,7 +86,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-29 03:54:59.091737",
+ "modified": "2025-10-15 15:36:49.231466",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Team",


### PR DESCRIPTION
### **User description**
Increase allocated_percentage precision to 5.


___

### **PR Type**
Bug fix


___

### **Description**
- Increased precision of `allocated_percentage` field to 5 decimal places in Sales Team doctype

- Updated metadata timestamp for the Sales Team doctype


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_team.json</strong><dd><code>Set precision for contribution percentage field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_team/sales_team.json

<ul><li>Added <code>precision</code> attribute with value "5" to the <code>allocated_percentage</code> <br>field<br> <li> Updated the <code>modified</code> timestamp to reflect the change</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/149/files#diff-be57f8289b3cba680a75af612cf98b345a35870791089904a901cded34b948ae">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

