### PR TITLE
Feat(r2): Setup to upload  public files

### DIFF
--- a/erpnext/r2_storage.py
+++ b/erpnext/r2_storage.py
@@ -148,21 +148,11 @@ class R2FileManager:
 	
 	def get_file_url(self, s3_key, file_name, is_private):
 		"""Generate appropriate URL for file"""
-		if is_private:
-			# Private files: use API endpoint for streaming
-			method = "erpnext.r2_storage.stream_from_r2"
-			encoded_key = quote(s3_key, safe="/")
-			encoded_name = quote(file_name or "")
-			return f"/api/method/{method}?key={encoded_key}&file_name={encoded_name}"
-		else:
-			# Public files: use direct URL or custom domain
-			if self.settings.get("public_url"):
-				encoded_key = quote(s3_key, safe="/")
-				return f"{self.settings['public_url']}/{encoded_key}"
-			else:
-				# Use R2 endpoint URL
-				encoded_key = quote(s3_key, safe="/")
-				return f"{self.settings['endpoint_url']}/{self.bucket}/{encoded_key}"
+		# Both public and private files use API endpoint
+		method = "erpnext.r2_storage.stream_from_r2"
+		encoded_key = quote(s3_key, safe="/")
+		encoded_name = quote(file_name or "")
+		return f"/api/method/{method}?key={encoded_key}&file_name={encoded_name}"
 	
 	def read_file(self, s3_key):
 		"""Read file from R2"""
@@ -231,9 +221,9 @@ def upload_to_r2(doc, method=None):
 		# Get file path on disk
 		site_path = get_site_path()
 		if not doc.is_private:
-			file_path = os.path.join(site_path, "public", doc.file_url.lstrip("/files/"))
+			file_path = os.path.join(site_path, "public", "files", doc.file_url.replace("/files/", ""))
 		else:
-			file_path = os.path.join(site_path, doc.file_url.lstrip("/"))
+			file_path = os.path.join(site_path, "private", "files", doc.file_url.replace("/private/files/", ""))
 		
 		# Check if file exists
 		if not os.path.exists(file_path):


### PR DESCRIPTION
### **User description**
___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Unified file URL generation for both public and private files

- Both file types now use API endpoint streaming method

- Fixed file path construction for public files directory

- Fixed file path construction for private files directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_file_url method"] -->|"Previously: conditional logic"| B["Private: API endpoint"]
  A -->|"Previously: conditional logic"| C["Public: direct/custom URL"]
  D["Updated get_file_url"] -->|"Now: unified approach"| E["API endpoint for all files"]
  F["upload_to_r2 function"] -->|"Fixed path construction"| G["public/files directory"]
  F -->|"Fixed path construction"| H["private/files directory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r2_storage.py</strong><dd><code>Unify file URL generation and fix path construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/r2_storage.py

<ul><li>Simplified <code>get_file_url</code> method to use API endpoint for both public and <br>private files<br> <li> Removed conditional logic that previously handled public files with <br>direct URLs<br> <li> Fixed file path construction in <code>upload_to_r2</code> for public files using <br>proper directory structure<br> <li> Fixed file path construction in <code>upload_to_r2</code> for private files using <br>proper directory structure</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/161/files#diff-6ddc554ef52230dc06bc4ad06681646b75fea333df934cd6971aaf749d3c536d">+7/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Unified file URL generation for both public and private files

- Both file types now use API endpoint streaming method

- Fixed file path construction for public files directory

- Fixed file path construction for private files directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_file_url method"] -->|"Before: conditional logic"| B["Private: API endpoint"]
  A -->|"Before: conditional logic"| C["Public: direct/custom URL"]
  D["Updated get_file_url"] -->|"After: unified approach"| E["API endpoint for all files"]
  F["upload_to_r2 function"] -->|"Fixed path construction"| G["public/files directory"]
  F -->|"Fixed path construction"| H["private/files directory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r2_storage.py</strong><dd><code>Unify file URL generation and fix path construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/r2_storage.py

<ul><li>Simplified <code>get_file_url</code> method to use API endpoint for both public and <br>private files<br> <li> Removed conditional logic that previously handled public files with <br>direct URLs<br> <li> Fixed file path construction in <code>upload_to_r2</code> for public files using <br>proper <code>public/files</code> directory structure<br> <li> Fixed file path construction in <code>upload_to_r2</code> for private files using <br>proper <code>private/files</code> directory structure</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/161/files#diff-6ddc554ef52230dc06bc4ad06681646b75fea333df934cd6971aaf749d3c536d">+7/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

