### PR TITLE
Feat(sales order): setup order group

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -52,6 +52,91 @@ frappe.ui.form.on("Sales Order", {
 			$statusSpan.css("color", "tomato").css("background-color", "whitesmoke");
 		}
 
+		// Show split order indicator and add button to view related orders
+		if (frm.doc.is_split_order && frm.doc.split_order_group) {
+			// Check if this is the group representative
+			const is_representative = frm.doc.haravan_order_id === frm.doc.split_order_group;
+			
+			// Add indicator
+			if (is_representative) {
+				frm.dashboard.add_indicator(
+					__('Split Order Group: {0} (Representative)', [frm.doc.split_order_group]), 
+					'orange'
+				);
+			} else {
+				frm.dashboard.add_indicator(
+					__('Split Order Group: {0}', [frm.doc.split_order_group]), 
+					'blue'
+				);
+			}
+			
+			// Add button to view related split orders
+			frm.add_custom_button(__('View Related Split Orders'), function() {
+				frappe.route_options = {
+					"split_order_group": frm.doc.split_order_group,
+					"is_split_order": 1,
+					"cancelled_status": "Uncancelled"
+				};
+				frappe.set_route("List", "Sales Order");
+			}, __("Actions"));
+			
+			// Load and display related split orders in the form
+			frappe.call({
+				method: 'frappe.client.get_list',
+				args: {
+					doctype: 'Sales Order',
+					filters: {
+						'split_order_group': frm.doc.split_order_group,
+						'is_split_order': 1,
+						'cancelled_status': 'Uncancelled'
+					},
+					fields: ['name', 'order_number', 'grand_total', 'haravan_order_id'],
+					order_by: 'transaction_date asc',
+					limit_page_length: 20
+				},
+				callback: function(r) {
+					if (r.message && r.message.length > 0) {
+						// Calculate total of all orders in group
+						let total_group_amount = 0;
+						let all_orders = r.message;
+						
+						all_orders.forEach(function(order) {
+							total_group_amount += order.grand_total || 0;
+						});
+						
+						let html = '<div class="split-orders-info" style="margin-top: 10px; padding: 10px; background-color: #f0f4f7; border-radius: 5px;">';
+						html += '<h6 style="margin-bottom: 10px; color: #3498db;"><i class="fa fa-link"></i> All Orders in Split Group:</h6>';
+						html += '<ul style="margin: 0; padding-left: 20px;">';
+						
+						all_orders.forEach(function(order) {
+							const is_rep = order.haravan_order_id === frm.doc.split_order_group;
+							const is_current = order.name === frm.doc.name;
+							
+							let badge = '';
+							if (is_rep) {
+								badge = '<span style="background: orange; color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px; margin-left: 5px;">REP</span>';
+							}
+							if (is_current) {
+								badge += '<span style="background: #27ae60; color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px; margin-left: 5px;">THIS</span>';
+							}
+							
+							const style = is_current ? 'font-weight: bold;' : '';
+							html += `<li style="${style}"><a href="/app/sales-order/${order.name}" target="_blank">${order.order_number}</a> - ${format_currency(order.grand_total, frm.doc.currency)}${badge}</li>`;
+						});
+						
+						html += '</ul>';
+						html += '<div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #d1d8dd;">';
+						html += `<p style="margin: 5px 0; font-size: 12px; color: #666;">Orders in group: <b>${all_orders.length}</b></p>`;
+						html += `<p style="margin: 5px 0; font-size: 13px; color: #2c3e50;"><b>Total Amount (All Split Orders): ${format_currency(total_group_amount, frm.doc.currency)}</b></p>`;
+						html += '</div>';
+						html += '</div>';
+						
+						frm.set_df_property('split_order_group', 'description', html);
+					}
+				}
+			});
+		}
+
 		frm.add_custom_button(__('View On Haravan'), function() {
 			const haravanUrl = `https://jemmiavn.myharavan.com/admin/orders/${frm.doc.haravan_order_id}`;
 			window.open(haravanUrl, '_blank');

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -54,18 +54,21 @@ frappe.ui.form.on("Sales Order", {
 
 		// Show split order indicator and add button to view related orders
 		if (frm.doc.is_split_order && frm.doc.split_order_group) {
-			// Check if this is the group representative
-			const is_representative = frm.doc.haravan_order_id === frm.doc.split_order_group;
+			// Format split_order_group for display (add # prefix for readability)
+			const formatted_group = `#${frm.doc.split_order_group}`;
+			
+			// Check if this is the original order (group origin)
+			const is_original = frm.doc.haravan_order_id === frm.doc.split_order_group;
 			
 			// Add indicator
-			if (is_representative) {
+			if (is_original) {
 				frm.dashboard.add_indicator(
-					__('Split Order Group: {0} (Representative)', [frm.doc.split_order_group]), 
+					__('Split Order Group: {0} (Original Order)', [formatted_group]), 
 					'orange'
 				);
 			} else {
 				frm.dashboard.add_indicator(
-					__('Split Order Group: {0}', [frm.doc.split_order_group]), 
+					__('Split Order Group: {0}', [formatted_group]), 
 					'blue'
 				);
 			}
@@ -109,12 +112,12 @@ frappe.ui.form.on("Sales Order", {
 						html += '<ul style="margin: 0; padding-left: 20px;">';
 						
 						all_orders.forEach(function(order) {
-							const is_rep = order.haravan_order_id === frm.doc.split_order_group;
+							const is_original = order.haravan_order_id === frm.doc.split_order_group;
 							const is_current = order.name === frm.doc.name;
 							
 							let badge = '';
-							if (is_rep) {
-								badge = '<span style="background: orange; color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px; margin-left: 5px;">REP</span>';
+							if (is_original) {
+								badge = '<span style="background: #95a5a6; color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px; margin-left: 5px;">ORIGINAL</span>';
 							}
 							if (is_current) {
 								badge += '<span style="background: #27ae60; color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px; margin-left: 5px;">THIS</span>';

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1786,6 +1786,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Split Order Group",
+   "permlevel": 1,
    "print_hide": 1
   },
   {
@@ -1794,6 +1795,7 @@
    "fieldname": "is_split_order",
    "fieldtype": "Check",
    "label": "Is Split Order",
+   "permlevel": 1,
    "print_hide": 1
   },
   {
@@ -2105,7 +2107,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-11 07:49:18.325654",
+ "modified": "2025-11-11 09:35:10.835404",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -23,6 +23,11 @@
   "po_date",
   "company",
   "amended_from",
+  "group_order_section",
+  "split_order_group",
+  "column_break_wcaf",
+  "is_split_order",
+  "split_reason",
   "section_break_uceh",
   "customer_name",
   "order_number",
@@ -1775,6 +1780,31 @@
    "read_only": 1
   },
   {
+   "description": "Group ID for orders split due to gold regulations",
+   "fieldname": "split_order_group",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Split Order Group",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "description": "Check if this order is part of a split group",
+   "fieldname": "is_split_order",
+   "fieldtype": "Check",
+   "label": "Is Split Order",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.is_split_order==1",
+   "fieldname": "split_reason",
+   "fieldtype": "Select",
+   "label": "Split Reason",
+   "options": "\nGold Regulation\nCustomer Request\nOther",
+   "print_hide": 1
+  },
+  {
    "fieldname": "haravan_created_at",
    "fieldtype": "Datetime",
    "label": "Haravan Created At",
@@ -2060,13 +2090,22 @@
    "fieldname": "custom_all_images_html",
    "fieldtype": "HTML",
    "label": "Attached images"
+  },
+  {
+   "fieldname": "group_order_section",
+   "fieldtype": "Section Break",
+   "label": "Group Order"
+  },
+  {
+   "fieldname": "column_break_wcaf",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-07 21:32:18.549915",
+ "modified": "2025-11-11 07:49:18.325654",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -24,6 +24,7 @@
   "company",
   "amended_from",
   "group_order_section",
+  "split_order_group_name",
   "split_order_group",
   "column_break_wcaf",
   "is_split_order",
@@ -1780,12 +1781,10 @@
    "read_only": 1
   },
   {
-   "description": "Group ID for orders split due to gold regulations",
+   "description": "Group ID for orders splitt",
    "fieldname": "split_order_group",
    "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Split Order Group",
+   "label": "Split Order Group ID",
    "permlevel": 1,
    "print_hide": 1
   },
@@ -2101,13 +2100,21 @@
   {
    "fieldname": "column_break_wcaf",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "split_order_group_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Split Order Group Name",
+   "permlevel": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-11 09:35:10.835404",
+ "modified": "2025-11-12 03:35:32.748323",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -809,12 +809,10 @@ class SalesOrder(SellingController):
 
 	def before_save(self):
 		self.validate_primary_sales_team()
-		self.handle_order_cancellation()
 		self.process_debt_history()
 		self.handle_serial_numbers_changes()
 		
 	def before_insert(self):
-		self.handle_order_cancellation()
 		self.process_debt_history()
 
 	def process_debt_history(self):

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -15,7 +15,7 @@ from frappe.desk.notifications import clear_doctype_notifications
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.utils import get_fetch_values
 from frappe.query_builder.functions import Sum
-from frappe.utils import add_days, cint, cstr, flt, get_link_to_form, getdate, nowdate, strip_html
+from frappe.utils import add_days, cint, cstr, flt, get_link_to_form, getdate, nowdate, strip_html, add_to_date, get_datetime
 
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 	unlink_inter_company_doc,
@@ -829,7 +829,8 @@ class SalesOrder(SellingController):
 	def after_insert(self):
 		self.update_customer_revenue_fields()
 		self.copy_from_reference_order()
-
+		self.auto_detect_split_orders()
+		
 	def before_submit(self):
 		frappe.throw(_("Sales Order Submission is not allowed."))
 
@@ -871,19 +872,64 @@ class SalesOrder(SellingController):
 				{"haravan_order_id": self.haravan_ref_order_id}, "name")
 			if not ref_order_name:
 				return	
+			# Define simple fields to copy (data types)
+			simple_fields = [
+				'consultation_date', 'primary_sales_person',
+				'deposit_location', 'delivery_location', 'expected_delivery_date',
+				'customer_type', 'expected_payment_date',
+				'deposit_amount', 'deposit_method',
+				'order_currency', 'billing_address',
+				'deposit_in_words', 'is_split_order', 'split_order_group',
+				'split_reason',
+			]
+					
+			# Copy simple fields
+			ref_data = frappe.db.get_value("Sales Order", ref_order_name, simple_fields, as_dict=True)			
+			if ref_data:
+				update_fields = {}
+				for field in simple_fields:
+					ref_value = getattr(ref_data, field, None)
+					current_value = getattr(self, field, None)
+					if ref_value and not current_value:
+						update_fields[field] = ref_value
+				
+				if update_fields:
+					for field, value in update_fields.items():
+						frappe.db.set_value("Sales Order", self.name, field, value)
 			
-			# Get ref order document
+			# Copy Table MultiSelect fields
 			ref_order_doc = frappe.get_doc("Sales Order", ref_order_name)
-			
-			# Detect if this is a split order or reorder
-			if self._is_split_order(ref_order_doc):
-				self._handle_split_order(ref_order_doc)
-			else:
-				self._handle_reorder(ref_order_doc)
-			
-			# Continue with common copy logic
-			self._copy_common_fields(ref_order_doc)
-			
+			multiselect_fields = {
+				# parentfield: link_field
+				"policies": "policy",
+				"promotions": "promotion",
+				"product_categories": "product_category",
+				"sales_order_purposes": "purchase_purpose"
+			}
+
+			for parentfield, link_field in multiselect_fields.items():
+				current_rows = self.get(parentfield) or []
+				ref_rows = ref_order_doc.get(parentfield) or []
+
+				if not current_rows and ref_rows:
+					for ref_row in ref_rows:
+						child = self.append(parentfield, {link_field: getattr(ref_row, link_field)})
+						child.db_insert()
+
+			# Copy Table fields
+			table_fields = ["sales_team", "debt_history"]
+			for parentfield in table_fields:
+				current_rows = self.get(parentfield) or []
+				ref_rows = ref_order_doc.get(parentfield) or []
+				if not current_rows and ref_rows:
+					for ref_row in ref_rows:
+						row = copy.deepcopy(ref_row.as_dict())
+						# remove system fields
+						for k in ("name", "parent", "parenttype", "parentfield", "creation", "modified", "modified_by", "owner", "docstatus", "idx"):
+							row.pop(k, None)
+						child = self.append(parentfield, row)
+						child.db_insert()
+
 			# Copy Sales Order Items
 			self.copy_sales_order_items_from_reference(ref_order_doc)
 		
@@ -892,134 +938,6 @@ class SalesOrder(SellingController):
 		
 		except Exception as e:
 			frappe.log_error(f"Error copying from reference order: {str(e)}")
-	
-	def _is_split_order(self, ref_order):
-		"""
-		Detect if current order is split from reference order
-		
-		Criteria: Ref order is still active (not cancelled)
-		If ref order is cancelled, it's a reorder (replacement)
-		If ref order is active, it's a split (both orders coexist)
-		"""
-		return ref_order.cancelled_status == "Uncancelled"
-	
-	def _handle_split_order(self, ref_order):
-		"""Handle when this order is split from another order"""
-		
-		# Determine split group ID
-		if ref_order.split_order_group:
-			# Ref order already has group, use it
-			split_group_id = ref_order.split_order_group
-		elif ref_order.is_split_order:
-			# Ref is already a split order, use its haravan_order_id
-			split_group_id = ref_order.haravan_order_id
-		else:
-			# This is the first split, create new group using ref order's ID
-			split_group_id = ref_order.haravan_order_id or ref_order.order_number
-		
-		# Set this order as split order
-		self.split_order_group = split_group_id
-		self.is_split_order = 1
-		self.split_reason = "Gold Regulation"
-		
-		# Update ref order if not marked yet
-		if not ref_order.is_split_order:
-			frappe.db.set_value("Sales Order", ref_order.name, {
-				"split_order_group": split_group_id,
-				"is_split_order": 1,
-				"split_reason": "Gold Regulation"
-			}, update_modified=False)
-		
-		frappe.msgprint(
-			_("This order is part of split group: <b>{0}</b>").format(split_group_id),
-			indicator="blue",
-			title=_("Split Order Detected")
-		)
-	
-	def _handle_reorder(self, ref_order):
-		"""Handle reorder case (existing logic for ref_sales_orders)"""
-		# Add to ref_sales_orders table for tracking reorder history
-		if not any(r.sales_order == ref_order.name for r in self.get("ref_sales_orders", [])):
-			self.append("ref_sales_orders", {
-				"sales_order": ref_order.name
-			})
-		
-		# Check if ref order was part of a split group
-		# If yes, inherit the SAME split group (group name never changes)
-		if ref_order.is_split_order and ref_order.split_order_group:
-			# Inherit the same group name from ref order
-			# Group name is FIXED = haravan_order_id of the first order in group
-			self.split_order_group = ref_order.split_order_group
-			self.is_split_order = 1
-			self.split_reason = ref_order.split_reason or "Gold Regulation"
-			
-			frappe.msgprint(
-				_("This order replaces {0} in split group: <b>{1}</b>").format(
-					frappe.bold(ref_order.name), 
-					ref_order.split_order_group
-				),
-				indicator="blue",
-				title=_("Split Order Replacement")
-			)
-	
-	
-	def _copy_common_fields(self, ref_order_doc):
-		"""Copy common fields from reference order"""
-		# Define simple fields to copy (data types)
-		simple_fields = [
-			'consultation_date', 'primary_sales_person',
-			'deposit_location', 'delivery_location', 'expected_delivery_date',
-			'customer_type', 'expected_payment_date',
-			'deposit_amount', 'deposit_method',
-			'order_currency', 'billing_address',
-			'deposit_in_words'
-		]
-				
-		# Copy simple fields
-		ref_data = frappe.db.get_value("Sales Order", ref_order_doc.name, simple_fields, as_dict=True)			
-		if ref_data:
-			update_fields = {}
-			for field in simple_fields:
-				ref_value = getattr(ref_data, field, None)
-				current_value = getattr(self, field, None)
-				if ref_value and not current_value:
-					update_fields[field] = ref_value
-			
-			if update_fields:
-				for field, value in update_fields.items():
-					frappe.db.set_value("Sales Order", self.name, field, value)
-		
-		# Copy Table MultiSelect fields
-		multiselect_fields = {
-			# parentfield: link_field
-			"policies": "policy",
-			"promotions": "promotion",
-			"product_categories": "product_category",
-			"sales_order_purposes": "purchase_purpose",
-		}
-
-		for parentfield, link_field in multiselect_fields.items():
-			current_rows = self.get(parentfield) or []
-			ref_rows = ref_order_doc.get(parentfield) or []
-
-			if not current_rows and ref_rows:
-				for ref_row in ref_rows:
-					child = self.append(parentfield, {link_field: getattr(ref_row, link_field)})
-					child.db_insert()
-
-		# Copy Table fields
-		table_fields = ["sales_team", "debt_history"]
-		for parentfield in table_fields:
-			current_rows = self.get(parentfield) or []
-			ref_rows = ref_order_doc.get(parentfield) or []
-			if not current_rows and ref_rows:
-				for ref_row in ref_rows:
-					row = copy.deepcopy(ref_row.as_dict())
-					# remove system fields
-					for k in ("name", "parent", "parenttype", "parentfield", "creation", "modified", "modified_by", "owner", "docstatus", "idx"):
-						row.pop(k, None)
-					child = self.append(parentfield, row)
-					child.db_insert()
 
 	def copy_attachments_from_reference(self, ref_order_name):
 		"""Copy attachments from reference order to current order"""
@@ -1249,6 +1167,77 @@ class SalesOrder(SellingController):
 				items_updated = True
 		
 		return items_updated
+
+	def auto_detect_split_orders(self):
+		"""
+		Auto-detect split orders based on customer and order creation time
+		"""
+
+		# Skip if not is_split_order
+		if self.is_split_order:
+			return
+		# Skip if no haravan_created_at (cannot detect time-based)
+		if not self.haravan_created_at:
+			return
+		
+		# Calculate time window (30 minutes BEFORE current order time only)
+		order_time = get_datetime(self.haravan_created_at)
+		time_window_start = add_to_date(order_time, minutes=-30)
+		
+		# Find orders from same customer created within 30 minutes before
+		# Only look for new orders (not reorders) to avoid grouping unrelated orders
+		previous_orders = frappe.db.sql("""
+			SELECT 
+				name, haravan_order_id, haravan_created_at,
+				split_order_group, is_split_order
+			FROM `tabSales Order`
+			WHERE customer = %s
+				AND haravan_created_at >= %s
+				AND haravan_created_at < %s
+				AND name != %s
+				AND cancelled_status = 'Uncancelled'
+			LIMIT 10
+		""", (self.customer, time_window_start, order_time, self.name), as_dict=True)
+		
+		if not previous_orders:
+			frappe.db.sql("""
+				UPDATE `tabSales Order`
+				SET split_order_group = %s,
+					is_split_order = 0
+				WHERE name = %s
+				ORDER BY haravan_created_at ASC
+			""", (self.haravan_order_id, self.name))
+			
+			frappe.db.commit()
+			return
+		
+		# Found related order(s) → This is a split order
+		first_previous_order = previous_orders[0]
+		
+		# Get group ID from previous order
+		split_group_id = first_previous_order.split_order_group or first_previous_order.haravan_order_id
+		
+		# Set this order as split order
+		frappe.db.sql("""
+			UPDATE `tabSales Order`
+			SET split_order_group = %s,
+				is_split_order = 1,
+				split_reason = 'Gold Regulation'
+			WHERE name = %s
+		""", (split_group_id, self.name))
+		
+		# Update all previous orders to mark as split orders
+		for prev_order in previous_orders:
+			# Always update to ensure is_split_order = 1
+			frappe.db.sql("""
+				UPDATE `tabSales Order`
+				SET split_order_group = %s,
+					is_split_order = 1,
+					split_reason = 'Gold Regulation'
+				WHERE name = %s
+			""", (split_group_id, prev_order.name))
+		
+		frappe.db.commit()
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:
 	"""Returns the unreserved quantity for the Sales Order Item."""

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -144,6 +144,7 @@ class SalesOrder(SellingController):
 		incoterm: DF.Link | None
 		inter_company_order_reference: DF.Link | None
 		is_internal_customer: DF.Check
+		is_split_order: DF.Check
 		items: DF.Table[SalesOrderItem]
 		language: DF.Data | None
 		letter_head: DF.Link | None
@@ -195,6 +196,8 @@ class SalesOrder(SellingController):
 		skip_delivery_note: DF.Check
 		source: DF.Link | None
 		source_name: DF.Data | None
+		split_order_group: DF.Data | None
+		split_reason: DF.Literal["", "Gold Regulation", "Customer Request", "Other"]
 		status: DF.Literal["", "Draft", "On Hold", "To Deliver and Bill", "To Bill", "To Deliver", "Completed", "Cancelled", "Closed"]
 		tax_category: DF.Link | None
 		tax_id: DF.Data | None
@@ -870,63 +873,19 @@ class SalesOrder(SellingController):
 				{"haravan_order_id": self.haravan_ref_order_id}, "name")
 			if not ref_order_name:
 				return	
-			# Define simple fields to copy (data types)
-			simple_fields = [
-				'consultation_date', 'primary_sales_person',
-				'deposit_location', 'delivery_location', 'expected_delivery_date',
-				'customer_type', 'expected_payment_date',
-				'deposit_amount', 'deposit_method',
-				'order_currency', 'billing_address',
-				'deposit_in_words'
-			]
-					
-			# Copy simple fields
-			ref_data = frappe.db.get_value("Sales Order", ref_order_name, simple_fields, as_dict=True)			
-			if ref_data:
-				update_fields = {}
-				for field in simple_fields:
-					ref_value = getattr(ref_data, field, None)
-					current_value = getattr(self, field, None)
-					if ref_value and not current_value:
-						update_fields[field] = ref_value
-				
-				if update_fields:
-					for field, value in update_fields.items():
-						frappe.db.set_value("Sales Order", self.name, field, value)
 			
-			# Copy Table MultiSelect fields
+			# Get ref order document
 			ref_order_doc = frappe.get_doc("Sales Order", ref_order_name)
-			multiselect_fields = {
-				# parentfield: link_field
-				"policies": "policy",
-				"promotions": "promotion",
-				"product_categories": "product_category",
-				"sales_order_purposes": "purchase_purpose",
-			}
-
-			for parentfield, link_field in multiselect_fields.items():
-				current_rows = self.get(parentfield) or []
-				ref_rows = ref_order_doc.get(parentfield) or []
-
-				if not current_rows and ref_rows:
-					for ref_row in ref_rows:
-						child = self.append(parentfield, {link_field: getattr(ref_row, link_field)})
-						child.db_insert()
-
-			# Copy Table fields
-			table_fields = ["sales_team", "debt_history"]
-			for parentfield in table_fields:
-				current_rows = self.get(parentfield) or []
-				ref_rows = ref_order_doc.get(parentfield) or []
-				if not current_rows and ref_rows:
-					for ref_row in ref_rows:
-						row = copy.deepcopy(ref_row.as_dict())
-						# remove system fields
-						for k in ("name", "parent", "parenttype", "parentfield", "creation", "modified", "modified_by", "owner", "docstatus", "idx"):
-							row.pop(k, None)
-						child = self.append(parentfield, row)
-						child.db_insert()
-
+			
+			# Detect if this is a split order or reorder
+			if self._is_split_order(ref_order_doc):
+				self._handle_split_order(ref_order_doc)
+			else:
+				self._handle_reorder(ref_order_doc)
+			
+			# Continue with common copy logic
+			self._copy_common_fields(ref_order_doc)
+			
 			# Copy Sales Order Items
 			self.copy_sales_order_items_from_reference(ref_order_doc)
 		
@@ -935,6 +894,134 @@ class SalesOrder(SellingController):
 		
 		except Exception as e:
 			frappe.log_error(f"Error copying from reference order: {str(e)}")
+	
+	def _is_split_order(self, ref_order):
+		"""
+		Detect if current order is split from reference order
+		
+		Criteria: Ref order is still active (not cancelled)
+		If ref order is cancelled, it's a reorder (replacement)
+		If ref order is active, it's a split (both orders coexist)
+		"""
+		return ref_order.cancelled_status == "Uncancelled"
+	
+	def _handle_split_order(self, ref_order):
+		"""Handle when this order is split from another order"""
+		
+		# Determine split group ID
+		if ref_order.split_order_group:
+			# Ref order already has group, use it
+			split_group_id = ref_order.split_order_group
+		elif ref_order.is_split_order:
+			# Ref is already a split order, use its haravan_order_id
+			split_group_id = ref_order.haravan_order_id
+		else:
+			# This is the first split, create new group using ref order's ID
+			split_group_id = ref_order.haravan_order_id or ref_order.order_number
+		
+		# Set this order as split order
+		self.split_order_group = split_group_id
+		self.is_split_order = 1
+		self.split_reason = "Gold Regulation"
+		
+		# Update ref order if not marked yet
+		if not ref_order.is_split_order:
+			frappe.db.set_value("Sales Order", ref_order.name, {
+				"split_order_group": split_group_id,
+				"is_split_order": 1,
+				"split_reason": "Gold Regulation"
+			}, update_modified=False)
+		
+		frappe.msgprint(
+			_("This order is part of split group: <b>{0}</b>").format(split_group_id),
+			indicator="blue",
+			title=_("Split Order Detected")
+		)
+	
+	def _handle_reorder(self, ref_order):
+		"""Handle reorder case (existing logic for ref_sales_orders)"""
+		# Add to ref_sales_orders table for tracking reorder history
+		if not any(r.sales_order == ref_order.name for r in self.get("ref_sales_orders", [])):
+			self.append("ref_sales_orders", {
+				"sales_order": ref_order.name
+			})
+		
+		# Check if ref order was part of a split group
+		# If yes, inherit the SAME split group (group name never changes)
+		if ref_order.is_split_order and ref_order.split_order_group:
+			# Inherit the same group name from ref order
+			# Group name is FIXED = haravan_order_id of the first order in group
+			self.split_order_group = ref_order.split_order_group
+			self.is_split_order = 1
+			self.split_reason = ref_order.split_reason or "Gold Regulation"
+			
+			frappe.msgprint(
+				_("This order replaces {0} in split group: <b>{1}</b>").format(
+					frappe.bold(ref_order.name), 
+					ref_order.split_order_group
+				),
+				indicator="blue",
+				title=_("Split Order Replacement")
+			)
+	
+	
+	def _copy_common_fields(self, ref_order_doc):
+		"""Copy common fields from reference order"""
+		# Define simple fields to copy (data types)
+		simple_fields = [
+			'consultation_date', 'primary_sales_person',
+			'deposit_location', 'delivery_location', 'expected_delivery_date',
+			'customer_type', 'expected_payment_date',
+			'deposit_amount', 'deposit_method',
+			'order_currency', 'billing_address',
+			'deposit_in_words'
+		]
+				
+		# Copy simple fields
+		ref_data = frappe.db.get_value("Sales Order", ref_order_doc.name, simple_fields, as_dict=True)			
+		if ref_data:
+			update_fields = {}
+			for field in simple_fields:
+				ref_value = getattr(ref_data, field, None)
+				current_value = getattr(self, field, None)
+				if ref_value and not current_value:
+					update_fields[field] = ref_value
+			
+			if update_fields:
+				for field, value in update_fields.items():
+					frappe.db.set_value("Sales Order", self.name, field, value)
+		
+		# Copy Table MultiSelect fields
+		multiselect_fields = {
+			# parentfield: link_field
+			"policies": "policy",
+			"promotions": "promotion",
+			"product_categories": "product_category",
+			"sales_order_purposes": "purchase_purpose",
+		}
+
+		for parentfield, link_field in multiselect_fields.items():
+			current_rows = self.get(parentfield) or []
+			ref_rows = ref_order_doc.get(parentfield) or []
+
+			if not current_rows and ref_rows:
+				for ref_row in ref_rows:
+					child = self.append(parentfield, {link_field: getattr(ref_row, link_field)})
+					child.db_insert()
+
+		# Copy Table fields
+		table_fields = ["sales_team", "debt_history"]
+		for parentfield in table_fields:
+			current_rows = self.get(parentfield) or []
+			ref_rows = ref_order_doc.get(parentfield) or []
+			if not current_rows and ref_rows:
+				for ref_row in ref_rows:
+					row = copy.deepcopy(ref_row.as_dict())
+					# remove system fields
+					for k in ("name", "parent", "parenttype", "parentfield", "creation", "modified", "modified_by", "owner", "docstatus", "idx"):
+						row.pop(k, None)
+					child = self.append(parentfield, row)
+					child.db_insert()
 
 	def copy_attachments_from_reference(self, ref_order_name):
 		"""Copy attachments from reference order to current order"""
@@ -2206,3 +2293,42 @@ def larksuite_notification(sales_order_doc):
 	)
 	message = response.json()["message"]
 	return message
+
+
+@frappe.whitelist()
+def get_split_orders_in_group(split_order_group, include_cancelled=False):
+	"""
+	Get all orders in a split order group
+	
+	Args:
+		split_order_group: The split order group ID
+		include_cancelled: Whether to include cancelled orders
+	
+	Returns:
+		List of orders in the group with details
+	"""
+	if not split_order_group:
+		return []
+	
+	filters = {
+		"split_order_group": split_order_group,
+		"is_split_order": 1
+	}
+	
+	if not include_cancelled:
+		filters["cancelled_status"] = "Uncancelled"
+	
+	orders = frappe.get_all("Sales Order",
+		filters=filters,
+		fields=[
+			"name", "order_number", "customer", "customer_name",
+			"grand_total", "currency", "haravan_order_id", 
+			"cancelled_status", "financial_status", "fulfillment_status",
+			"transaction_date", "modified"
+		],
+		order_by="transaction_date asc"
+	)
+	for order in orders:
+		order["is_original_order"] = (order.get("haravan_order_id") == split_order_group)
+	
+	return orders

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -197,6 +197,7 @@ class SalesOrder(SellingController):
 		source: DF.Link | None
 		source_name: DF.Data | None
 		split_order_group: DF.Data | None
+		split_order_group_name: DF.Data | None
 		split_reason: DF.Literal["", "Gold Regulation", "Customer Request", "Other"]
 		status: DF.Literal["", "Draft", "On Hold", "To Deliver and Bill", "To Bill", "To Deliver", "Completed", "Cancelled", "Closed"]
 		tax_category: DF.Link | None
@@ -879,7 +880,8 @@ class SalesOrder(SellingController):
 				'customer_type', 'expected_payment_date',
 				'deposit_amount', 'deposit_method',
 				'order_currency', 'billing_address',
-				'deposit_in_words', 'is_split_order', 'split_order_group',
+				'deposit_in_words', 'is_split_order',
+				'split_order_group', 'split_order_group_name',
 				'split_reason',
 			]
 					
@@ -1203,10 +1205,11 @@ class SalesOrder(SellingController):
 			frappe.db.sql("""
 				UPDATE `tabSales Order`
 				SET split_order_group = %s,
+					split_order_group_name = %s,
 					is_split_order = 0
 				WHERE name = %s
 				ORDER BY haravan_created_at ASC
-			""", (self.haravan_order_id, self.name))
+			""", (self.haravan_order_id, self.order_number, self.name))
 			
 			frappe.db.commit()
 			return
@@ -1216,15 +1219,17 @@ class SalesOrder(SellingController):
 		
 		# Get group ID from previous order
 		split_group_id = first_previous_order.split_order_group or first_previous_order.haravan_order_id
+		split_group_name = first_previous_order.split_order_group_name or first_previous_order.order_number
 		
 		# Set this order as split order
 		frappe.db.sql("""
 			UPDATE `tabSales Order`
 			SET split_order_group = %s,
+				split_order_group_name = %s,
 				is_split_order = 1,
 				split_reason = 'Gold Regulation'
 			WHERE name = %s
-		""", (split_group_id, self.name))
+		""", (split_group_id, split_group_name, self.name))
 		
 		# Update all previous orders to mark as split orders
 		for prev_order in previous_orders:
@@ -1232,10 +1237,11 @@ class SalesOrder(SellingController):
 			frappe.db.sql("""
 				UPDATE `tabSales Order`
 				SET split_order_group = %s,
+					split_order_group_name = %s,
 					is_split_order = 1,
 					split_reason = 'Gold Regulation'
 				WHERE name = %s
-			""", (split_group_id, prev_order.name))
+			""", (split_group_id, split_group_name, prev_order.name))
 		
 		frappe.db.commit()
 

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -60,6 +60,18 @@ frappe.listview_settings["Sales Order"] = {
 				$('span[data-filter="financial_status,=,Paid"]').addClass('green');
 				$('span[data-filter="financial_status,=,Partially Paid"]').addClass('gray');
 				$('span[data-filter="financial_status,=,Pending"]').addClass('blue');
+				
+				// Split Order Indicator - Add badge to order number
+				for (let i = 0; i < listview.data.length; i++) {
+					const row_data = listview.data[i];
+					if (row_data.is_split_order && row_data.split_order_group) {
+						const is_rep = row_data.haravan_order_id === row_data.split_order_group;
+						const badge_color = is_rep ? 'orange' : '#3498db';
+						const badge_text = is_rep ? 'GROUP REP' : 'SPLIT';
+						const badge = `<span style="background: ${badge_color}; color: white; padding: 2px 6px; border-radius: 3px; font-size: 9px; margin-left: 5px; font-weight: bold;">${badge_text}</span>`;
+						$(`.result .list-row-container:nth-child(${i + 3}) .list-row-col:nth-child(1)`).append(badge);
+					}
+				}
 			});
 			observer.observe(resultEl, { childList: true, subtree: true });
 		}

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -65,10 +65,7 @@ frappe.listview_settings["Sales Order"] = {
 				for (let i = 0; i < listview.data.length; i++) {
 					const row_data = listview.data[i];
 					if (row_data.is_split_order && row_data.split_order_group) {
-						const is_rep = row_data.haravan_order_id === row_data.split_order_group;
-						const badge_color = is_rep ? 'orange' : '#3498db';
-						const badge_text = is_rep ? 'GROUP REP' : 'SPLIT';
-						const badge = `<span style="background: ${badge_color}; color: white; padding: 2px 6px; border-radius: 3px; font-size: 9px; margin-left: 5px; font-weight: bold;">${badge_text}</span>`;
+						const badge = `<span style="background: #3498db; color: white; padding: 2px 6px; border-radius: 3px; font-size: 9px; margin-left: 5px; font-weight: bold;">SPLIT</span>`;
 						$(`.result .list-row-container:nth-child(${i + 3}) .list-row-col:nth-child(1)`).append(badge);
 					}
 				}


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add split order detection and grouping functionality for gold regulation compliance

- Introduce new fields (`is_split_order`, `split_order_group`, `split_reason`) to track order splits

- Auto-detect split orders within 30-minute time window for same customer

- Display split order indicators and related orders in UI with visual badges

- Remove cancelled order handling logic from before_save and before_insert hooks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SO["Sales Order Created"] --> AD["Auto-detect Split Orders"]
  AD --> TW["Check 30-min Time Window"]
  TW --> PO["Find Previous Orders"]
  PO --> GRP["Group Related Orders"]
  GRP --> UI["Display Split Indicators"]
  UI --> VIEW["View Related Orders"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Add split order detection and grouping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<ul><li>Add imports for <code>add_to_date</code> and <code>get_datetime</code> utilities<br> <li> Add new fields <code>is_split_order</code> and <code>split_order_group</code> to doctype <br>definition<br> <li> Remove <code>handle_order_cancellation()</code> calls from <code>before_save()</code> and <br><code>before_insert()</code> hooks<br> <li> Implement <code>auto_detect_split_orders()</code> method to detect and group split <br>orders within 30-minute window<br> <li> Add <code>get_split_orders_in_group()</code> whitelist function to retrieve all <br>orders in a split group<br> <li> Update <code>copy_from_reference_order()</code> to include split order fields when <br>copying from reference</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/162/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+119/-6</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales_order.js</strong><dd><code>Add UI indicators and related orders display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.js

<ul><li>Add split order indicator to dashboard showing group ID and original <br>order status<br> <li> Add "View Related Split Orders" button to navigate to filtered list of <br>split orders<br> <li> Load and display all related split orders with total amount <br>calculation<br> <li> Show badges indicating original order and current order in the split <br>group<br> <li> Display split orders info section with order details and group <br>statistics</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/162/files#diff-37381add523d6eaea087962721ecc1f33808612439eccec9d11a443168bc536e">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales_order_list.js</strong><dd><code>Add split order badges to list view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order_list.js

<ul><li>Add visual "SPLIT" badge to order number in list view for split orders<br> <li> Badge appears only when <code>is_split_order</code> is true and <code>split_order_group</code> <br>exists<br> <li> Enhance list view to highlight split orders for quick identification</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/162/files#diff-40eb5df81a395f1ebff57d1879b6f5ab9f789396ce36446b1923ff571dca8dc5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.json</strong><dd><code>Add split order fields to doctype schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.json

<ul><li>Add new section "Group Order" with split order related fields<br> <li> Add <code>split_order_group</code> field (Data type, in list view and standard <br>filter)<br> <li> Add <code>is_split_order</code> field (Check type, default 0)<br> <li> Add <code>split_reason</code> field (Select with options: Gold Regulation, Customer <br>Request, Other)<br> <li> Update field order to include new group order section<br> <li> Set permlevel 1 for split order fields to restrict access</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/162/files#diff-60468f41a3b442dc6134bd9661f3225db58882f960aac83ef55325cf7f7b980e">+42/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

