### PR TITLE
Feat(lead): Update stage when converted

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -181,6 +181,8 @@ class Lead(SellingController, CRMNote):
 			pass
 
 	def update_lead_stage(self):
+		if self.lead_stage=="Customer":
+			return
 
 		lead_stage = self.get_lead_stage()
 		

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -256,9 +256,7 @@ class Customer(TransactionBase):
 		self.validate_name_with_customer_group()
 		self.create_primary_contact()
 		self.create_primary_address()
-
-		if self.flags.old_lead != self.lead_name:
-			self.update_lead_status()
+		self.update_lead_status()
 
 		if self.flags.is_new_doc:
 			self.link_lead_address_and_contact()
@@ -299,7 +297,9 @@ class Customer(TransactionBase):
 		"""If Customer created from Lead, update lead status to "Converted"
 		update Customer link in Quotation, Opportunity"""
 		if self.lead_name:
-			frappe.db.set_value("Lead", self.lead_name, "status", "Converted")
+			update_values = {"status": "Converted"}
+			update_values["lead_stage"] = "Customer"
+			frappe.db.set_value("Lead", self.lead_name, update_values)
 
 	def link_lead_address_and_contact(self):
 		if self.lead_name:


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Update Lead stage to "Customer" when converted to Customer

- Prevent Lead stage from being overwritten after conversion

- Simplify Lead status update logic by removing conditional check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Customer Created/Updated"] -->|"calls update_lead_status()"| B["Set Lead status to Converted"]
  B -->|"also sets"| C["Lead stage to Customer"]
  D["update_lead_stage()"] -->|"checks if stage is Customer"| E["Returns early to prevent overwrite"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead.py</strong><dd><code>Prevent Lead stage overwrite after conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead.py

<ul><li>Add early return in <code>update_lead_stage()</code> when lead stage is already <br>"Customer"<br> <li> Prevents automatic stage updates from overwriting the "Customer" stage <br>after conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/165/files#diff-64a0af8f42900682b438917e3168d6ccc911231563f66c68fd21a532f237ccd4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>customer.py</strong><dd><code>Update Lead stage when Customer is converted</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.py

<ul><li>Remove conditional check <code>if self.flags.old_lead != self.lead_name</code> <br>before updating Lead status<br> <li> Update <code>update_lead_status()</code> to set both "status" to "Converted" and <br>"lead_stage" to "Customer"<br> <li> Simplify logic to always update Lead status when customer has a <br>lead_name</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/165/files#diff-6c864e7eb264f62092ce56e22731b2736152c26b9c8961d5039c8cb8b9361f2e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

