### PR TITLE
Enhance/priority/ranking with coupon

### DIFF
--- a/erpnext/selling/doctype/coupon/coupon.json
+++ b/erpnext/selling/doctype/coupon/coupon.json
@@ -16,7 +16,10 @@
   "coupon_type",
   "payment_status",
   "haravan_coupon_id",
-  "cashback_ref"
+  "cashback_ref",
+  "section_break_dates",
+  "start_date",
+  "end_date"
  ],
  "fields": [
   {
@@ -76,6 +79,23 @@
    "fieldname": "haravan_coupon_id",
    "fieldtype": "Data",
    "label": "Haravan Coupon ID"
+  },
+  {
+   "fieldname": "section_break_dates",
+   "fieldtype": "Section Break",
+   "label": "Dates"
+  },
+  {
+   "description": "When coupon became active",
+   "fieldname": "start_date",
+   "fieldtype": "Datetime",
+   "label": "Start Date"
+  },
+  {
+   "description": "When coupon was used by another customer",
+   "fieldname": "end_date",
+   "fieldtype": "Datetime",
+   "label": "End Date"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/erpnext/selling/doctype/coupon/coupon.py
+++ b/erpnext/selling/doctype/coupon/coupon.py
@@ -4,6 +4,7 @@ from frappe import _
 from frappe.utils import flt
 from frappe.model.document import Document
 from erpnext.config.config import config
+from frappe.utils import get_datetime
 
 class Coupon(Document):
 	# begin: auto-generated types
@@ -107,3 +108,87 @@ def update_all_customers_coupon_code():
 		frappe.db.rollback()
 		frappe.log_error(frappe.get_traceback(), "Error updating coupon codes")
 		frappe.throw(_("An error occurred while updating coupon codes: {0}").format(str(e)))
+
+@frappe.whitelist()
+def update_customers_coupons(customer_name, customer_haravan_id):
+	"""
+	Update coupons for a specific customer by fetching from Priority API.
+
+	Args:
+		customer_name: ERPNext Customer name
+		customer_haravan_id: Haravan ID of the customer
+	"""
+	try:
+		priority_bearer_token: str = config.PRIORITY_BEARER_TOKEN
+		priority_base_url: str = config.PRIORITY_BASE_URL
+		response = requests.get(
+			f"{priority_base_url}/sync-crm/coupon-ref?haravanId={customer_haravan_id}",
+			json={},
+			headers={"Authorization": f"Bearer {priority_bearer_token}"}
+		)
+
+		if response.status_code != 200:
+			return
+
+		customer_coupons = response.json()
+		if not customer_coupons:
+			return
+
+		# Early return if coupon count matches
+		current_coupon_count = frappe.db.count("Coupon", {"customer": customer_name})
+		if len(customer_coupons) == current_coupon_count:
+			return
+
+		for result in customer_coupons:
+			if not result.get("couponHaravanCode"):
+				continue
+
+			coupon_doc, existing_coupon = _map_coupon_from_api(result, customer_name)
+
+			if not existing_coupon:
+				coupon_doc.insert(ignore_permissions=True)
+			else:
+				coupon_doc.save(ignore_permissions=True)
+
+		frappe.db.commit()
+		customer_doc = frappe.get_doc("Customer", customer_name)
+		customer_doc.save(ignore_permissions=True)
+
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), f"Error updating coupons for customer {customer_name}")
+		return
+
+def _map_coupon_from_api(result, customer_name):
+	"""Map API response to Coupon document fields"""
+	haravan_coupon_id = result.get("couponHaravanId")
+	user_haravan_id = result.get("userHaravanId")
+	user = frappe.get_value("Customer", {"haravan_id": user_haravan_id}, "name") if user_haravan_id else None
+	existing_coupon = frappe.get_value("Coupon", {"haravan_coupon_id": haravan_coupon_id}, "name")
+
+	if existing_coupon:
+		coupon_doc = frappe.get_doc("Coupon", existing_coupon)
+	else:
+		coupon_doc = frappe.new_doc("Coupon")
+
+	coupon_doc.haravan_coupon_id = haravan_coupon_id
+	coupon_doc.coupon_name = result.get("couponHaravanCode")
+	coupon_doc.customer = customer_name
+	coupon_doc.user = user
+	coupon_doc.coupon_type = result.get("couponType", "Invite")
+	coupon_doc.total_price = flt(result.get("totalPrice", 0))
+	coupon_doc.cashback_ref = flt(result.get("cashBackRef", 0))
+	coupon_doc.payment_status = result.get("paymentStatus", "Pending").capitalize()
+
+	if result.get("startDate"):
+		dt = get_datetime(result.get("startDate"))
+		coupon_doc.start_date = dt.replace(tzinfo=None)
+
+	if result.get("endDate"):
+		dt = get_datetime(result.get("endDate"))
+		coupon_doc.end_date = dt.replace(tzinfo=None)
+
+	coupon_doc.parent = customer_name
+	coupon_doc.parentfield = "coupon_table"
+	coupon_doc.parenttype = "Customer"
+
+	return coupon_doc, existing_coupon

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -144,6 +144,22 @@ frappe.ui.form.on("Customer", {
 				}, 1500);
 			}
 
+			if (frm.doc.haravan_id && !frm._coupons_loaded) {
+				frm._coupons_loaded = true;
+				setTimeout(() => {
+					frappe.call({
+						method: "erpnext.selling.doctype.coupon.coupon.update_customers_coupons",
+						args: {
+							customer_name: frm.doc.name,
+							customer_haravan_id: parseInt(frm.doc.haravan_id)
+						},
+						callback: function (r) {
+							frm.reload_doc();
+						}
+					});
+				}, 2000);
+			}
+
 			frappe.contacts.render_address_and_contact(frm);
 
 			// Load customer orders

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -121,6 +121,7 @@
   "priority_login_date",
   "column_break_rm_1",
   "rank_score_12m",
+  "partner_role",
   "cumulative_revenue_management_section",
   "actual_cumulative_revenue",
   "column_break_ebsn",
@@ -896,7 +897,7 @@
    "fieldname": "rank",
    "fieldtype": "Select",
    "label": "Rank",
-   "options": "No Rank\nSilver\nGold\nPlatinum",
+   "options": "No Rank\nSilver\nGold\nPlatinum\nStaff",
    "read_only": 1
   },
   {
@@ -906,8 +907,7 @@
   {
    "fieldname": "priority_login_date",
    "fieldtype": "Date",
-   "label": "Priority Login Date",
-   "read_only": 1
+   "label": "Priority Login Date"
   },
   {
    "fieldname": "rank_updated_at",
@@ -923,6 +923,12 @@
    "fieldname": "rank_score_12m",
    "fieldtype": "Currency",
    "label": "Rank Score (12 Months)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "partner_role",
+   "fieldtype": "Data",
+   "label": "Partner Role",
    "read_only": 1
   },
   {

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -897,7 +897,7 @@
    "fieldname": "rank",
    "fieldtype": "Select",
    "label": "Rank",
-   "options": "No Rank\nSilver\nGold\nPlatinum\nStaff",
+   "options": "No Rank\nSilver\nGold\nPlatinum",
    "read_only": 1
   },
   {

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -896,7 +896,8 @@
    "fieldname": "rank",
    "fieldtype": "Select",
    "label": "Rank",
-   "options": "No Rank\nSilver\nGold\nPlatinum"
+   "options": "No Rank\nSilver\nGold\nPlatinum",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_qwps",
@@ -905,12 +906,14 @@
   {
    "fieldname": "priority_login_date",
    "fieldtype": "Date",
-   "label": "Priority Login Date"
+   "label": "Priority Login Date",
+   "read_only": 1
   },
   {
    "fieldname": "rank_updated_at",
    "fieldtype": "Date",
-   "label": "Rank Updated At"
+   "label": "Rank Updated At",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_rm_1",
@@ -919,7 +922,8 @@
   {
    "fieldname": "rank_score_12m",
    "fieldtype": "Currency",
-   "label": "Rank Score (12 Months)"
+   "label": "Rank Score (12 Months)",
+   "read_only": 1
   },
   {
    "fieldname": "rank_management_section",
@@ -934,7 +938,8 @@
   {
    "fieldname": "actual_cumulative_revenue",
    "fieldtype": "Currency",
-   "label": "Actual Cumulative Revenue"
+   "label": "Actual Cumulative Revenue",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_ebsn",
@@ -943,7 +948,8 @@
   {
    "fieldname": "referral_cumulative_revenue",
    "fieldtype": "Currency",
-   "label": "Referral Cumulative Revenue"
+   "label": "Referral Cumulative Revenue",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_qgzr",
@@ -952,7 +958,8 @@
   {
    "fieldname": "buyback_revenue",
    "fieldtype": "Currency",
-   "label": "Buyback Revenue"
+   "label": "Buyback Revenue",
+   "read_only": 1
   },
   {
    "fieldname": "bizfly_customer_number",
@@ -973,12 +980,14 @@
   {
    "fieldname": "total_referral_point",
    "fieldtype": "Float",
-   "label": "Total Referral Point"
+   "label": "Total Referral Point",
+   "read_only": 1
   },
   {
    "fieldname": "available_point_amount",
    "fieldtype": "Float",
-   "label": "Available Point Amount"
+   "label": "Available Point Amount",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_pnc1",
@@ -987,12 +996,14 @@
   {
    "fieldname": "withdraw_point",
    "fieldtype": "Float",
-   "label": "Withdraw points"
+   "label": "Withdraw points",
+   "read_only": 1
   },
   {
    "fieldname": "withdraw_cash_amount",
    "fieldtype": "Currency",
-   "label": "Total Withdrawn Cash Amount"
+   "label": "Total Withdrawn Cash Amount",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_pnc2",
@@ -1001,7 +1012,8 @@
   {
    "fieldname": "withdraw_cash_amount_pending",
    "fieldtype": "Currency",
-   "label": "Pending Withdraw Cash Amount"
+   "label": "Pending Withdraw Cash Amount",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_pnc3",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -906,6 +906,7 @@ def update_customer_priority_data(customer_name, haravan_id):
 	withdraw_cash_amount = data.get("withdrawCashAmount", 0)
 	withdraw_cash_pending = data.get("pendingCashback", 0)
 	total_referral_point = data.get("totalPoint", 0)
+	partner_role = data.get("role", "")  # Get role from Priority API (staff, partnerA, partnerB, etc.)
 
 	# Update customer fields (referral_cumulative_revenue removed - now calculated from coupons)
 	frappe.db.sql("""
@@ -916,10 +917,11 @@ def update_customer_priority_data(customer_name, haravan_id):
 			available_point_amount = %s,
 			withdraw_cash_amount = %s,
 			withdraw_cash_amount_pending = %s,
-			total_referral_point = %s
+			total_referral_point = %s,
+			partner_role = %s
 		WHERE name = %s
 	""", (actual_revenue, withdraw_point, available_point, withdraw_cash_amount,
-			withdraw_cash_pending, total_referral_point, customer_name))
+			withdraw_cash_pending, total_referral_point, partner_role, customer_name))
 
 	frappe.db.commit()
 
@@ -1242,21 +1244,22 @@ def _check_12_month_downgrades(customer_name, auto_commit=True):
 	"""Phase 3: Check if 12-month downgrade evaluation is needed"""
 	from frappe.utils import add_months, getdate, nowdate
 
-	# after finish implementing phase 3, if role either staff, partnerA, partnerB, return do not downgrade
-
 	customer = frappe.get_doc("Customer", customer_name)
 	rank_updated_at = customer.rank_updated_at
 	current_rank = customer.rank
 
-	if not rank_updated_at or current_rank == CustomerRank.SILVER:
-		return  # No downgrade needed for Silver
+	if not rank_updated_at:
+		return
+
+	partner_role = (getattr(customer, 'partner_role', '') or '').lower()
+	is_protected = partner_role in ["staff", "partnera", "partnerb"]
 
 	# Check if 12 months have passed (handle multiple periods if stuck)
 	today = getdate(nowdate())
 	next_evaluation_date = add_months(rank_updated_at, 12)
 
 	# Handle users stuck at old dates - evaluate one period at a time
-	while today >= next_evaluation_date and current_rank != CustomerRank.SILVER:
+	while today >= next_evaluation_date:
 		# Calculate 12-month score (orders + referral in the 12-month window)
 		orders_12m = _calculate_12_month_score(customer_name, rank_updated_at)
 		referral_12m = _get_referral_revenue_in_12_month_period(customer_name, rank_updated_at)
@@ -1268,17 +1271,23 @@ def _check_12_month_downgrades(customer_name, auto_commit=True):
 		# Check if downgrade is needed
 		if _is_rank_lower(qualified_rank, current_rank):
 			downgraded_rank = _downgrade_one_level(current_rank)
-			customer.db_set("rank", downgraded_rank, update_modified=True)
+
+			if not is_protected and current_rank != CustomerRank.SILVER:
+				customer.db_set("rank", downgraded_rank, update_modified=True)
+				frappe.logger().info(f"Downgraded {customer_name} from {current_rank} to {downgraded_rank} (12m score: {rank_score_12m})")
+				current_rank = downgraded_rank
+			elif is_protected:
+				frappe.logger().info(f"Protected role {partner_role}: Skipped downgrade for {customer_name} (12m score: {rank_score_12m})")
+			else:
+				frappe.logger().info(f"Already at Silver: No downgrade for {customer_name} (12m score: {rank_score_12m})")
+
+			# Always update dates and score (even for protected roles and Silver)
 			customer.db_set("rank_updated_at", next_evaluation_date, update_modified=True)
 			customer.db_set("rank_score_12m", rank_score_12m, update_modified=True)
 
 			if auto_commit:
 				frappe.db.commit()
 
-			frappe.logger().info(f"Downgraded {customer_name} from {current_rank} to {downgraded_rank} (12m score: {rank_score_12m})")
-
-			# Update for next iteration
-			current_rank = downgraded_rank
 			rank_updated_at = next_evaluation_date
 			next_evaluation_date = add_months(rank_updated_at, 12)
 		else:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -900,28 +900,26 @@ def update_customer_priority_data(customer_name, haravan_id):
 		AND cancelled_status = 'Uncancelled'
 	""", (customer_name,), as_dict=True)[0].total or 0
 
-	# Extract referral and point data from Priority API
-	referral_revenue = data.get("referralsRevenue", 0)
+	# Extract point data from Priority API (referral revenue now comes from coupons)
 	withdraw_point = data.get("withdrawPoint", 0)
 	available_point = data.get("pointAvailable", 0)
 	withdraw_cash_amount = data.get("withdrawCashAmount", 0)
 	withdraw_cash_pending = data.get("pendingCashback", 0)
 	total_referral_point = data.get("totalPoint", 0)
 
-	# Update customer fields
+	# Update customer fields (referral_cumulative_revenue removed - now calculated from coupons)
 	frappe.db.sql("""
 		UPDATE `tabCustomer`
 		SET
 			actual_cumulative_revenue = %s,
-			referral_cumulative_revenue = %s,
 			withdraw_point = %s,
 			available_point_amount = %s,
 			withdraw_cash_amount = %s,
 			withdraw_cash_amount_pending = %s,
 			total_referral_point = %s
 		WHERE name = %s
-	""", (actual_revenue, referral_revenue, withdraw_point, available_point,
-	      withdraw_cash_amount, withdraw_cash_pending, total_referral_point, customer_name))
+	""", (actual_revenue, withdraw_point, available_point, withdraw_cash_amount,
+			withdraw_cash_pending, total_referral_point, customer_name))
 
 	frappe.db.commit()
 
@@ -1032,11 +1030,28 @@ def _calculate_12_month_score(customer_name, rank_updated_at):
 
 	actual_revenue = flt(sales_orders[0].total if sales_orders else 0)
 
-	customer = frappe.get_doc("Customer", customer_name)
-	referral_revenue = flt(customer.get("referral_cumulative_revenue", 0))
-
 	# For rank evaluation, only count purchasing activity (no buyback subtraction)
 	return actual_revenue
+
+def _get_referral_revenue_in_12_month_period(customer_name, rank_updated_at):
+	"""Get referral revenue earned in the 12-month period after rank_updated_at
+	Uses coupon end_date to determine when referral was earned"""
+	from frappe.utils import add_months, getdate
+
+	start_date = getdate(rank_updated_at)
+	end_date = add_months(start_date, 12)
+
+	referral_revenue = frappe.db.sql("""
+		SELECT SUM(total_price) as total
+		FROM `tabCoupon`
+		WHERE customer = %s
+		AND end_date IS NOT NULL
+		AND end_date > %s
+		AND end_date < %s
+		AND payment_status IN ('Paid', 'Pending')
+	""", (customer_name, start_date, end_date), as_dict=True)
+
+	return flt(referral_revenue[0].total if referral_revenue else 0)
 
 def _get_buyback_revenue_in_period(customer_name, start_date, end_date):
 	"""
@@ -1170,9 +1185,9 @@ def _initialize_customer_rank(customer_name, auto_commit=True):
 	# Calculate cumulative revenue at first order date
 	cumulative_at_first_order = _get_cumulative_revenue_at_date(customer_name, first_order_date)
 
-	# Determine initial rank
-	referral_revenue = flt(customer.get("referral_cumulative_revenue", 0))
-	initial_rank = _determine_rank_from_cumulative(cumulative_at_first_order, referral_revenue)
+	# Get referral revenue at first order date (for threshold logic only)
+	referral_at_first_order = _get_referral_revenue_up_to_date(customer_name, first_order_date)
+	initial_rank = _determine_rank_from_cumulative(cumulative_at_first_order, referral_at_first_order)
 
 	customer.db_set("rank", initial_rank, update_modified=True)
 
@@ -1200,7 +1215,6 @@ def _replay_rank_upgrades(customer_name, auto_commit=True):
 	if not orders:
 		return
 
-	referral_revenue = flt(customer.get("referral_cumulative_revenue", 0))
 	current_rank = customer.rank
 
 	for order in orders:
@@ -1209,8 +1223,9 @@ def _replay_rank_upgrades(customer_name, auto_commit=True):
 		# Calculate cumulative revenue up to this order date
 		cumulative_at_date = _get_cumulative_revenue_at_date(customer_name, order_date)
 
-		# Check if this qualifies for an upgrade
-		qualified_rank = _determine_rank_from_cumulative(cumulative_at_date, referral_revenue)
+		# Get referral revenue at this date (for threshold logic only)
+		referral_at_date = _get_referral_revenue_up_to_date(customer_name, order_date)
+		qualified_rank = _determine_rank_from_cumulative(cumulative_at_date, referral_at_date)
 
 		if _is_rank_higher(qualified_rank, current_rank):
 			# Upgrade found! Update rank and rank_updated_at
@@ -1227,25 +1242,28 @@ def _check_12_month_downgrades(customer_name, auto_commit=True):
 	"""Phase 3: Check if 12-month downgrade evaluation is needed"""
 	from frappe.utils import add_months, getdate, nowdate
 
+	# after finish implementing phase 3, if role either staff, partnerA, partnerB, return do not downgrade
+
 	customer = frappe.get_doc("Customer", customer_name)
-	rank_updated_at = customer.rank_updated_at
 	rank_updated_at = customer.rank_updated_at
 	current_rank = customer.rank
 
 	if not rank_updated_at or current_rank == CustomerRank.SILVER:
 		return  # No downgrade needed for Silver
 
-	# Check if 12 months have passed
+	# Check if 12 months have passed (handle multiple periods if stuck)
 	today = getdate(nowdate())
 	next_evaluation_date = add_months(rank_updated_at, 12)
 
-	if today >= next_evaluation_date:
-		# Calculate 12-month score (purchasing activity only)
-		rank_score_12m = _calculate_12_month_score(customer_name, rank_updated_at)
+	# Handle users stuck at old dates - evaluate one period at a time
+	while today >= next_evaluation_date and current_rank != CustomerRank.SILVER:
+		# Calculate 12-month score (orders + referral in the 12-month window)
+		orders_12m = _calculate_12_month_score(customer_name, rank_updated_at)
+		referral_12m = _get_referral_revenue_in_12_month_period(customer_name, rank_updated_at)
+		rank_score_12m = orders_12m + referral_12m
 
 		# Determine what rank the 12-month score qualifies for
-		referral_revenue = flt(customer.get("referral_cumulative_revenue", 0))
-		qualified_rank = _determine_rank_from_cumulative(rank_score_12m, referral_revenue)
+		qualified_rank = _determine_rank_from_cumulative(rank_score_12m, referral_12m)
 
 		# Check if downgrade is needed
 		if _is_rank_lower(qualified_rank, current_rank):
@@ -1258,13 +1276,24 @@ def _check_12_month_downgrades(customer_name, auto_commit=True):
 				frappe.db.commit()
 
 			frappe.logger().info(f"Downgraded {customer_name} from {current_rank} to {downgraded_rank} (12m score: {rank_score_12m})")
+
+			# Update for next iteration
+			current_rank = downgraded_rank
+			rank_updated_at = next_evaluation_date
+			next_evaluation_date = add_months(rank_updated_at, 12)
 		else:
-			# Update evaluation date even if no downgrade
+			# No downgrade, but still advance evaluation date
 			customer.db_set("rank_updated_at", next_evaluation_date, update_modified=True)
 			customer.db_set("rank_score_12m", rank_score_12m, update_modified=True)
 
 			if auto_commit:
 				frappe.db.commit()
+
+			frappe.logger().info(f"Maintained {customer_name} at {current_rank} (12m score: {rank_score_12m})")
+
+			# Update for next iteration
+			rank_updated_at = next_evaluation_date
+			next_evaluation_date = add_months(rank_updated_at, 12)
 
 def _get_cumulative_revenue_at_date(customer_name, target_date):
 	"""Calculate cumulative revenue up to a specific date (including that date)"""
@@ -1278,13 +1307,25 @@ def _get_cumulative_revenue_at_date(customer_name, target_date):
 		AND transaction_date <= %s
 	""", (customer_name, target_date), as_dict=True)[0].total or 0
 
-	# Get referral revenue (constant - we can't get historical breakdown)
-	customer = frappe.get_doc("Customer", customer_name)
-	referral_revenue = flt(customer.get("referral_cumulative_revenue", 0))
+	# Get referral revenue from coupons up to target_date (using end_date)
+	referral_revenue = _get_referral_revenue_up_to_date(customer_name, target_date)
 
 	# For historical replay, use gross revenue (no buyback subtraction)
 	# Buybacks are only considered in 12-month evaluations, not for upgrade qualifications
 	return flt(actual_revenue) + flt(referral_revenue)
+
+def _get_referral_revenue_up_to_date(customer_name, target_date):
+	"""Get referral revenue from coupons up to a specific date (using end_date)"""
+	referral_revenue = frappe.db.sql("""
+		SELECT SUM(total_price) as total
+		FROM `tabCoupon`
+		WHERE customer = %s
+		AND end_date IS NOT NULL
+		AND end_date <= %s
+		AND payment_status IN ('Paid', 'Pending')
+	""", (customer_name, target_date), as_dict=True)
+
+	return flt(referral_revenue[0].total if referral_revenue else 0)
 
 def _get_buyback_revenue_up_to_date(customer_name, target_date):
 	"""Get total buyback revenue up to a specific date"""
@@ -1322,7 +1363,9 @@ def _get_buyback_revenue_up_to_date(customer_name, target_date):
 		return 0
 
 def _update_total_cumulative_revenue(customer_name, auto_commit=True):
-	"""Update the total_cumulative_revenue field"""
+	"""Update the total_cumulative_revenue field
+	"""
+	_update_referral_revenue_from_coupons(customer_name)
 	customer = frappe.get_doc("Customer", customer_name)
 
 	actual_revenue = flt(customer.get("actual_cumulative_revenue", 0))
@@ -1334,3 +1377,16 @@ def _update_total_cumulative_revenue(customer_name, auto_commit=True):
 
 	if auto_commit:
 		frappe.db.commit()
+
+
+def _update_referral_revenue_from_coupons(customer_name):
+	"""Calculate referral_cumulative_revenue from sum of coupon total_price"""
+	total_referral = frappe.db.sql("""
+		SELECT SUM(total_price) as total
+		FROM `tabCoupon`
+		WHERE customer = %s
+		AND payment_status in ('Paid', 'Pending')
+	""", (customer_name,), as_dict=True)[0].total or 0
+
+	frappe.db.set_value("Customer", customer_name, "referral_cumulative_revenue", total_referral)
+	frappe.db.commit()


### PR DESCRIPTION
## Changes
- Use the customer's coupon to calculate the 12-month accumulative revenue before `rank_updated_at`
- Add `partner_role` to the Customer doctype
- Make several fields (revenue fields, rank, withdraw point, etc.) read-only




<img width="1345" height="760" alt="image" src="https://github.com/user-attachments/assets/88e64010-70ec-4f23-b61d-6ddee54f34c2" />