### PR TITLE
feat(erp) Revamp payment entry UI

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -140,8 +140,7 @@
    "fieldname": "transaction_id",
    "fieldtype": "Data",
    "label": "Transaction ID",
-   "read_only": 1,
-   "unique": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -754,23 +754,12 @@ frappe.ui.form.on("Payment Entry", {
 									frm.doc.payment_type == "Receive" &&
 									currency_field == "paid_to_account_currency"
 								) {
-									// Removed Bank-only validation - reference fields are now always optional
-									// frm.toggle_reqd(
-									// 	["reference_no", "reference_date"],
-									// 	r.message["account_type"] == "Bank" ? 1 : 0
-									// );
 									if (!frm.doc.received_amount && frm.doc.paid_amount)
 										frm.events.paid_amount(frm);
 								} else if (
 									frm.doc.payment_type == "Pay" &&
 									currency_field == "paid_from_account_currency"
 								) {
-									// Removed Bank-only validation - reference fields are now always optional
-									// frm.toggle_reqd(
-									// 	["reference_no", "reference_date"],
-									// 	r.message["account_type"] == "Bank" ? 1 : 0
-									// );
-
 									if (!frm.doc.paid_amount && frm.doc.received_amount)
 										frm.events.received_amount(frm);
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -296,6 +296,43 @@ frappe.ui.form.on("Payment Entry", {
 				window.open(frm.doc.qr_url);
 			}, qr_group);
 		}
+
+		// Add Verify button
+		if (
+			!frm.doc.verified_by &&
+			frm.doc.payment_order_status !== "Success" &&
+			frm.doc.payment_order_status !== "Cancel"
+		) {
+			frm.add_custom_button(__("Verify"), () => {
+				if (!frm.doc.bank_transactions || frm.doc.bank_transactions.length === 0) {
+					frappe.msgprint({
+						title: __("Cannot Verify"),
+						indicator: "red",
+						message: __("Payment Entry must have at least one Bank Transaction to verify.")
+					});
+					return;
+				}
+
+				if (!frm.doc.references || !frm.doc.references.some(r => r.reference_doctype === "Sales Order")) {
+					frappe.msgprint({
+						title: __("Cannot Verify"),
+						indicator: "red",
+						message: __("Payment Entry must have at least one Sales Order reference to verify.")
+					});
+					return;
+				}
+
+				frappe.call({
+					method: "verify_payment",
+					doc: frm.doc,
+					callback: function(r) {
+						if (!r.exc) {
+							frm.reload_doc();
+						}
+					}
+				});
+			});
+		}
 	},
 
 	validate: async function (frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -230,6 +230,15 @@ frappe.ui.form.on("Payment Entry", {
 			"payment_request_outstanding",
 			"Payment Entry Reference"
 		);
+
+		frm.set_query("bank_transaction", "bank_transactions", function() {
+			return {
+				query: "erpnext.accounts.doctype.payment_entry.payment_entry.get_bank_transactions",
+				filters: {
+					company: frm.doc.company
+				}
+			};
+		});
 	},
 
 	update_bank_branch_logic: function (frm) {
@@ -304,11 +313,12 @@ frappe.ui.form.on("Payment Entry", {
 			frm.doc.payment_order_status !== "Cancel"
 		) {
 			frm.add_custom_button(__("Verify"), () => {
-				if (!frm.doc.bank_transactions || frm.doc.bank_transactions.length === 0) {
+				let skip_bank_check = ["Cash", "COD"].includes(frm.doc.mode_of_payment);
+				if (!skip_bank_check && (!frm.doc.bank_transactions || frm.doc.bank_transactions.length === 0)) {
 					frappe.msgprint({
 						title: __("Cannot Verify"),
 						indicator: "red",
-						message: __("Payment Entry must have at least one Bank Transaction to verify.")
+						message: __("Payment Entry must have at least one Bank Transaction to verify (unless Mode of Payment is Cash or COD).")
 					});
 					return;
 				}
@@ -1984,3 +1994,19 @@ function prompt_for_missing_account(frm, account) {
 function get_deduction_amount_precision() {
 	return frappe.meta.get_field_precision(frappe.meta.get_field("Payment Entry Deduction", "amount"));
 }
+
+frappe.ui.form.on("Payment Entry Bank Transaction", {
+	bank_transaction: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.bank_transaction) {
+			frappe.db.get_value("Bank Transaction", row.bank_transaction, ["date", "deposit", "sepay_transaction_content"], (r) => {
+				if (r) {
+					frappe.model.set_value(cdt, cdn, "date", r.date);
+					let amount = r.deposit || r.withdrawal || 0;
+					frappe.model.set_value(cdt, cdn, "allocated_amount", amount);
+					frappe.model.set_value(cdt, cdn, "sepay_transaction_content", r.sepay_transaction_content);
+				}
+			});
+		}
+	}
+});

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -40,6 +40,7 @@ frappe.ui.form.on("Payment Entry", {
 		});
 
 		if (frm.is_new()) {
+			frm.set_value("created_by_display", frappe.session.user);
 			set_default_party_type(frm);
 		}
 	},

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -239,6 +239,18 @@ frappe.ui.form.on("Payment Entry", {
 				}
 			};
 		});
+
+		frm.set_query("reference_name", "references", function(doc, cdt, cdn) {
+			let row = locals[cdt][cdn];
+			if (row.reference_doctype === "Sales Order") {
+				return {
+					query: "erpnext.accounts.doctype.payment_entry.payment_entry.get_sales_orders_for_payment",
+					filters: {
+						company: frm.doc.company
+					}
+				};
+			}
+		});
 	},
 
 	update_bank_branch_logic: function (frm) {
@@ -1837,6 +1849,13 @@ frappe.ui.form.on("Payment Entry", {
 });
 
 frappe.ui.form.on("Payment Entry Reference", {
+	references_add: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (!row.reference_doctype) {
+			frappe.model.set_value(cdt, cdn, "reference_doctype", "Sales Order");
+		}
+	},
+
 	reference_doctype: function (frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
 		frm.events.validate_reference_document(frm, row);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -670,20 +670,22 @@ frappe.ui.form.on("Payment Entry", {
 									frm.doc.payment_type == "Receive" &&
 									currency_field == "paid_to_account_currency"
 								) {
-									frm.toggle_reqd(
-										["reference_no", "reference_date"],
-										r.message["account_type"] == "Bank" ? 1 : 0
-									);
+									// Removed Bank-only validation - reference fields are now always optional
+									// frm.toggle_reqd(
+									// 	["reference_no", "reference_date"],
+									// 	r.message["account_type"] == "Bank" ? 1 : 0
+									// );
 									if (!frm.doc.received_amount && frm.doc.paid_amount)
 										frm.events.paid_amount(frm);
 								} else if (
 									frm.doc.payment_type == "Pay" &&
 									currency_field == "paid_from_account_currency"
 								) {
-									frm.toggle_reqd(
-										["reference_no", "reference_date"],
-										r.message["account_type"] == "Bank" ? 1 : 0
-									);
+									// Removed Bank-only validation - reference fields are now always optional
+									// frm.toggle_reqd(
+									// 	["reference_no", "reference_date"],
+									// 	r.message["account_type"] == "Bank" ? 1 : 0
+									// );
 
 									if (!frm.doc.paid_amount && frm.doc.received_amount)
 										frm.events.received_amount(frm);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -232,7 +232,31 @@ frappe.ui.form.on("Payment Entry", {
 		);
 	},
 
+	update_bank_branch_logic: function (frm) {
+		if (["Wire Transfer", "QR"].includes(frm.doc.mode_of_payment)) {
+			frm.set_df_property("bank_account_branch", "read_only", 1);
+			if (frm.doc.bank_account) {
+				frappe.db.get_value("Bank Account", frm.doc.bank_account, "account_type", (r) => {
+					if (r && r.account_type) {
+						frm.set_df_property("bank_account_branch", "options", [r.account_type]);
+						frm.set_value("bank_account_branch", r.account_type);
+					}
+				});
+			} else {
+				frm.set_value("bank_account_branch", "");
+			}
+		} else {
+			frm.set_df_property("bank_account_branch", "options", [
+				"Cửa hàng HCM",
+				"Cửa hàng Cần Thơ",
+				"Cửa hàng Hà Nội",
+			]);
+			frm.set_df_property("bank_account_branch", "read_only", 0);
+		}
+	},
+
 	refresh: function (frm) {
+		frm.events.update_bank_branch_logic(frm);
 		erpnext.hide_company(frm);
 		frm.events.hide_unhide_fields(frm);
 		frm.events.set_dynamic_labels(frm);
@@ -470,6 +494,7 @@ frappe.ui.form.on("Payment Entry", {
 		erpnext.accounts.pos.get_payment_mode_account(frm, frm.doc.mode_of_payment, function (account) {
 			let payment_account_field = frm.doc.payment_type == "Receive" ? "paid_to" : "paid_from";
 			frm.set_value(payment_account_field, account);
+			frm.events.update_bank_branch_logic(frm);
 		});
 	},
 
@@ -1397,6 +1422,7 @@ frappe.ui.form.on("Payment Entry", {
 						}
 						frm.set_value("bank", r.message.bank);
 						frm.set_value("bank_account_no", r.message.bank_account_no);
+						frm.events.update_bank_branch_logic(frm);
 					}
 				},
 			});

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -3,16 +3,19 @@
  "allow_auto_repeat": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
- "creation": "2016-06-01 14:38:51.012597",
+ "creation": "2025-12-03 14:08:40.555886",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "bank_transactions_section",
+  "bank_transactions",
   "type_of_payment",
   "naming_series",
   "name_display",
   "payment_type",
   "payment_order_status",
   "created_by_display",
+  "verified_by",
   "column_break_5",
   "posting_date",
   "mode_of_payment",
@@ -89,8 +92,6 @@
   "column_break_23",
   "reference_date",
   "clearance_date",
-  "bank_transactions_section",
-  "bank_transactions",
   "accounting_dimensions_section",
   "dimension_col_break_2",
   "misa_synced",
@@ -520,7 +521,6 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
    "fieldname": "bank_transactions_section",
    "fieldtype": "Section Break",
    "label": "Bank Transactions"
@@ -873,6 +873,14 @@
    "read_only_depends_on": "doc.owner"
   },
   {
+   "depends_on": "eval:doc.verified_by",
+   "fieldname": "verified_by",
+   "fieldtype": "Link",
+   "label": "Verified By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
    "depends_on": "eval:doc.mode_of_payment == 'Wire Transfer' || doc.mode_of_payment == 'QR'",
    "fieldname": "qr_section_break",
    "fieldtype": "Section Break",
@@ -944,7 +952,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-02 13:58:43.023686",
+ "modified": "2025-12-03 14:26:59.234983",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -523,14 +523,14 @@
   {
    "fieldname": "bank_transactions_section",
    "fieldtype": "Section Break",
-   "label": "Bank Transactions"
+   "label": "Bank Transactions",
+   "depends_on": "eval:!doc.__islocal"
   },
   {
    "fieldname": "bank_transactions",
    "fieldtype": "Table",
    "label": "Bank Transactions",
-   "options": "Payment Entry Bank Transaction",
-   "read_only": 1
+   "options": "Payment Entry Bank Transaction"
   },
   {
    "collapsible": 1,
@@ -952,7 +952,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-03 14:26:59.234983",
+ "modified": "2025-12-03 14:31:30.538490",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -15,10 +15,10 @@
   "created_by_display",
   "column_break_5",
   "posting_date",
+  "mode_of_payment",
   "company",
   "bank_account",
   "bank_account_branch",
-  "mode_of_payment",
   "qr_section_break",
   "custom_transaction_id",
   "custom_transfer_status",
@@ -629,7 +629,6 @@
    "read_only": 1
   },
   {
-   "depends_on": "party",
    "fieldname": "bank_account",
    "fieldtype": "Link",
    "label": "Company Bank Account",
@@ -921,11 +920,10 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "bank_account.account_type",
-   "fetch_if_empty": 1,
    "fieldname": "bank_account_branch",
-   "fieldtype": "Read Only",
-   "label": "Branch"
+   "fieldtype": "Select",
+   "label": "Branch",
+   "options": "C\u1eeda h\u00e0ng HCM\nC\u1eeda h\u00e0ng C\u1ea7n Th\u01a1\nC\u1eeda h\u00e0ng H\u00e0 N\u1ed9i"
   },
   {
    "fieldname": "name_display",
@@ -946,7 +944,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-02 12:03:14.708762",
+ "modified": "2025-12-02 13:58:43.023686",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -9,24 +9,29 @@
  "field_order": [
   "type_of_payment",
   "naming_series",
+  "name_display",
   "payment_type",
   "payment_order_status",
-  "custom_transaction_id",
-  "custom_transfer_note",
-  "custom_transfer_status",
-  "qr_url",
+  "created_by_display",
   "column_break_5",
   "posting_date",
   "company",
+  "bank_account",
+  "bank_account_branch",
   "mode_of_payment",
+  "qr_section_break",
+  "custom_transaction_id",
+  "custom_transfer_status",
+  "column_break_redx",
+  "custom_transfer_note",
+  "qr_url",
   "party_section",
   "party_type",
-  "party",
   "party_name",
   "book_advance_payments_in_separate_party_account",
   "reconcile_on_advance_payment_date",
   "column_break_11",
-  "bank_account",
+  "party",
   "party_bank_account",
   "contact_person",
   "contact_email",
@@ -42,12 +47,13 @@
   "paid_to_account_currency",
   "paid_to_account_balance",
   "payment_amounts_section",
-  "paid_amount",
+  "total_order_amount",
   "paid_amount_after_tax",
   "source_exchange_rate",
   "base_paid_amount",
   "base_paid_amount_after_tax",
   "column_break_21",
+  "paid_amount",
   "received_amount",
   "received_amount_after_tax",
   "target_exchange_rate",
@@ -83,9 +89,16 @@
   "column_break_23",
   "reference_date",
   "clearance_date",
+  "bank_transactions_section",
+  "bank_transactions",
   "accounting_dimensions_section",
+  "dimension_col_break_2",
+  "misa_synced",
+  "misa_sync_guid",
   "project",
   "dimension_col_break",
+  "misa_synced_at",
+  "misa_sync_error_msg",
   "cost_center",
   "section_break_12",
   "status",
@@ -148,16 +161,18 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Company",
    "options": "Company",
    "print_hide": 1,
    "remember_last_selected_value": 1,
-   "reqd": 1
+   "report_hide": 1
   },
   {
    "allow_on_submit": 1,
    "fieldname": "cost_center",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Cost Center",
    "options": "Cost Center"
   },
@@ -172,26 +187,30 @@
    "fieldname": "custom_transaction_id",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Custom Transaction ID"
+   "label": "QR Transaction ID",
+   "read_only": 1
   },
   {
    "fieldname": "custom_transfer_note",
    "fieldtype": "Small Text",
    "in_list_view": 1,
-   "label": "Custom Transfer Note"
+   "label": "Transfer Note",
+   "read_only": 1
   },
   {
    "fieldname": "custom_transfer_status",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Custom Transfer Status",
-   "options": "\npending\nsuccess\ncancel"
+   "label": "Transfer Status",
+   "options": "\npending\nsuccess\ncancel",
+   "read_only": 1
   },
   {
    "fieldname": "qr_url",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "QR URL"
+   "label": "QR URL",
+   "read_only": 1
   },
   {
    "depends_on": "eval:in_list([\"Receive\", \"Pay\"], doc.payment_type)",
@@ -200,13 +219,12 @@
    "label": "Payment From / To"
   },
   {
-   "depends_on": "eval:in_list([\"Receive\", \"Pay\"], doc.payment_type) && doc.docstatus==0",
+   "bold": 1,
    "fieldname": "party_type",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Party Type",
    "options": "DocType",
-   "print_hide": 1,
    "search_index": 1
   },
   {
@@ -223,6 +241,7 @@
    "depends_on": "eval:in_list([\"Receive\", \"Pay\"], doc.payment_type) && doc.party_type",
    "fieldname": "party_name",
    "fieldtype": "Data",
+   "hidden": 1,
    "in_global_search": 1,
    "label": "Party Name"
   },
@@ -234,6 +253,7 @@
    "depends_on": "eval: doc.party && doc.party_type !== \"Employee\"",
    "fieldname": "contact_person",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Contact",
    "options": "Contact"
   },
@@ -241,6 +261,7 @@
    "depends_on": "eval: (doc.contact_person || doc.party_type === \"Employee\") && doc.contact_email",
    "fieldname": "contact_email",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "Email",
    "options": "Email",
    "read_only": 1
@@ -249,6 +270,7 @@
    "collapsible": 1,
    "fieldname": "payment_accounts_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Accounts"
   },
   {
@@ -268,18 +290,17 @@
    "in_global_search": 1,
    "label": "Account Paid From",
    "options": "Account",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "depends_on": "paid_from",
    "fieldname": "paid_from_account_currency",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Account Currency (From)",
    "options": "Currency",
    "print_hide": 1,
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -299,21 +320,21 @@
    "depends_on": "eval:(in_list([\"Internal Transfer\", \"Receive\"], doc.payment_type) || doc.party)",
    "fieldname": "paid_to",
    "fieldtype": "Link",
+   "hidden": 1,
    "in_global_search": 1,
    "label": "Account Paid To",
    "options": "Account",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "depends_on": "paid_to",
    "fieldname": "paid_to_account_currency",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Account Currency (To)",
    "options": "Currency",
    "print_hide": 1,
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -342,19 +363,19 @@
   {
    "fieldname": "source_exchange_rate",
    "fieldtype": "Float",
+   "hidden": 1,
    "label": "Source Exchange Rate",
    "precision": "9",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "fieldname": "base_paid_amount",
    "fieldtype": "Currency",
+   "hidden": 1,
    "label": "Paid Amount (Company Currency)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break_21",
@@ -364,28 +385,29 @@
    "bold": 1,
    "fieldname": "received_amount",
    "fieldtype": "Currency",
+   "hidden": 1,
    "label": "Received Amount",
    "options": "paid_to_account_currency",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "fieldname": "target_exchange_rate",
    "fieldtype": "Float",
+   "hidden": 1,
    "label": "Target Exchange Rate",
    "precision": "9",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
+   "default": "0",
    "depends_on": "doc.received_amount",
    "fieldname": "base_received_amount",
    "fieldtype": "Currency",
+   "hidden": 1,
    "label": "Received Amount (Company Currency)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "depends_on": "eval:(doc.party && doc.paid_from && doc.paid_to && doc.paid_amount && doc.received_amount)",
@@ -402,7 +424,9 @@
   {
    "fieldname": "section_break_34",
    "fieldtype": "Section Break",
-   "label": "Writeoff"
+   "hidden": 1,
+   "label": "Writeoff",
+   "print_hide": 1
   },
   {
    "bold": 1,
@@ -454,6 +478,7 @@
    "depends_on": "eval:(doc.paid_amount && doc.received_amount)",
    "fieldname": "deductions_or_loss_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Deductions or Loss"
   },
   {
@@ -465,15 +490,14 @@
   {
    "fieldname": "transaction_references",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Transaction ID"
   },
   {
    "bold": 1,
-   "depends_on": "eval:(doc.paid_from && doc.paid_to)",
    "fieldname": "reference_no",
    "fieldtype": "Data",
-   "label": "Cheque/Reference No",
-   "mandatory_depends_on": "eval:(doc.paid_from_account_type == 'Bank' || doc.paid_to_account_type == 'Bank')"
+   "label": "Cheque/Reference No"
   },
   {
    "fieldname": "column_break_23",
@@ -481,11 +505,9 @@
   },
   {
    "bold": 1,
-   "depends_on": "eval:(doc.paid_from && doc.paid_to)",
    "fieldname": "reference_date",
    "fieldtype": "Date",
    "label": "Cheque/Reference Date",
-   "mandatory_depends_on": "eval:(doc.paid_from_account_type == 'Bank' || doc.paid_to_account_type == 'Bank')",
    "search_index": 1
   },
   {
@@ -499,15 +521,30 @@
   },
   {
    "collapsible": 1,
+   "fieldname": "bank_transactions_section",
+   "fieldtype": "Section Break",
+   "label": "Bank Transactions"
+  },
+  {
+   "fieldname": "bank_transactions",
+   "fieldtype": "Table",
+   "label": "Bank Transactions",
+   "options": "Payment Entry Bank Transaction",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
    "depends_on": "eval:(doc.paid_from && doc.paid_to && doc.paid_amount && doc.received_amount)",
    "fieldname": "section_break_12",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "More Information"
   },
   {
    "allow_on_submit": 1,
    "fieldname": "project",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Project",
    "options": "Project",
    "print_hide": 1
@@ -561,6 +598,7 @@
   {
    "fieldname": "subscription_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Subscription Section"
   },
   {
@@ -595,22 +633,25 @@
    "fieldname": "bank_account",
    "fieldtype": "Link",
    "label": "Company Bank Account",
-   "options": "Bank Account"
+   "options": "Bank Account",
+   "search_index": 1
   },
   {
    "depends_on": "party",
    "fieldname": "party_bank_account",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Party Bank Account",
    "options": "Bank Account"
   },
   {
+   "bold": 1,
+   "default": "Pending",
    "fieldname": "payment_order_status",
    "fieldtype": "Select",
-   "hidden": 1,
-   "label": "Payment Order Status",
+   "label": "Payment Status",
    "no_copy": 1,
-   "options": "Initiated\nPayment Ordered",
+   "options": "Pending\nSuccess\nCancel",
    "read_only": 1
   },
   {
@@ -643,7 +684,6 @@
    "fieldname": "tax_withholding_category",
    "fieldtype": "Link",
    "label": "Tax Withholding Category",
-   "mandatory_depends_on": "eval:doc.apply_tax_withholding_amount",
    "options": "Tax Withholding Category"
   },
   {
@@ -657,6 +697,7 @@
    "collapsible": 1,
    "fieldname": "taxes_and_charges_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Taxes and Charges"
   },
   {
@@ -699,6 +740,7 @@
    "hidden": 1,
    "label": "Paid Amount After Tax",
    "options": "paid_from_account_currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -707,6 +749,7 @@
    "hidden": 1,
    "label": "Paid Amount After Tax (Company Currency)",
    "options": "Company:company:default_currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -716,6 +759,7 @@
   {
    "fieldname": "section_break_56",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "hide_border": 1
   },
   {
@@ -725,6 +769,7 @@
    "hidden": 1,
    "label": "Received Amount After Tax",
    "options": "paid_to_account_currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -734,6 +779,7 @@
    "hidden": 1,
    "label": "Received Amount After Tax (Company Currency)",
    "options": "Company:company:default_currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -757,18 +803,21 @@
   {
    "fieldname": "section_break_60",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "hide_border": 1
   },
   {
    "depends_on": "eval:doc.docstatus==0",
    "fieldname": "get_outstanding_invoices",
    "fieldtype": "Button",
+   "hidden": 1,
    "label": "Get Outstanding Invoices"
   },
   {
    "depends_on": "eval:doc.docstatus==0",
    "fieldname": "get_outstanding_orders",
    "fieldtype": "Button",
+   "hidden": 1,
    "label": "Get Outstanding Orders"
   },
   {
@@ -814,6 +863,75 @@
    "options": "No\nYes",
    "print_hide": 1,
    "search_index": 1
+  },
+  {
+   "depends_on": "eval: doc.owner",
+   "fieldname": "created_by_display",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Created By",
+   "options": "User",
+   "read_only_depends_on": "doc.owner"
+  },
+  {
+   "depends_on": "eval:doc.mode_of_payment == 'Wire Transfer' || doc.mode_of_payment == 'QR'",
+   "fieldname": "qr_section_break",
+   "fieldtype": "Section Break",
+   "label": "QR Section"
+  },
+  {
+   "fieldname": "column_break_redx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_order_amount",
+   "fieldtype": "Currency",
+   "label": "Total Order Amount",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "misa_synced",
+   "fieldtype": "Check",
+   "label": "Misa Synced",
+   "options": "Project",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "misa_sync_guid",
+   "fieldtype": "Data",
+   "label": "Misa GUID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "misa_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Misa Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "misa_sync_error_msg",
+   "fieldtype": "Data",
+   "label": "Misa Failed Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "dimension_col_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "bank_account.account_type",
+   "fetch_if_empty": 1,
+   "fieldname": "bank_account_branch",
+   "fieldtype": "Read Only",
+   "label": "Branch"
+  },
+  {
+   "fieldname": "name_display",
+   "fieldtype": "Data",
+   "label": "ID",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -828,7 +946,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-11-16 02:28:55.090351",
+ "modified": "2025-12-02 12:03:14.708762",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -228,7 +228,10 @@ class PaymentEntry(AccountsController):
 		if not self.name:
 			return
 
-		self.bank_transactions = []
+
+		if self.bank_transactions:
+			return
+
 		linked_transactions = frappe.db.sql("""
 			SELECT
 				btp.parent as bank_transaction,
@@ -2050,8 +2053,9 @@ class PaymentEntry(AccountsController):
 	@frappe.whitelist()
 	def verify_payment(self):
 		"""Verify payment entry after bank transaction matching"""
-		if not self.bank_transactions or len(self.bank_transactions) == 0:
-			frappe.throw(_("Cannot verify: Payment Entry must have at least one Bank Transaction"))
+		skip_bank_check = self.mode_of_payment in ["Cash", "COD"]
+		if not skip_bank_check and (not self.bank_transactions or len(self.bank_transactions) == 0):
+			frappe.throw(_("Cannot verify: Payment Entry must have at least one Bank Transaction (unless Mode of Payment is Cash or COD)"))
 		has_sales_order = any(ref.reference_doctype == "Sales Order" for ref in self.references)
 		if not has_sales_order:
 			frappe.throw(_("Cannot verify: Payment Entry must have at least one Sales Order reference"))
@@ -3768,6 +3772,37 @@ def make_payment_order(source_name, target_doc=None):
 	return doclist
 
 
+
 @erpnext.allow_regional
 def add_regional_gl_entries(gl_entries, doc):
 	return
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_bank_transactions(doctype, txt, searchfield, start, page_len, filters):
+	"""Custom query to search Bank Transactions by name, bank_account, and sepay_transaction_content"""
+	return frappe.db.sql(
+		"""
+		SELECT name, bank_account, sepay_transaction_content
+		FROM `tabBank Transaction`
+		WHERE (
+			name LIKE %(txt)s
+			OR bank_account LIKE %(txt)s
+			OR sepay_transaction_content LIKE %(txt)s
+		)
+		{conditions}
+		ORDER BY
+			CASE WHEN name LIKE %(txt)s THEN 0 ELSE 1 END,
+			modified DESC
+		LIMIT %(page_len)s OFFSET %(start)s
+		""".format(
+			conditions=("AND company = %(company)s" if filters.get("company") else "Jemmia Diamond")
+		),
+		{
+			"txt": f"%{txt}%",
+			"company": filters.get("company"),
+			"start": start,
+			"page_len": page_len,
+		},
+	)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -79,7 +79,7 @@ class PaymentEntry(AccountsController):
 		auto_repeat: DF.Link | None
 		bank: DF.ReadOnly | None
 		bank_account: DF.Link | None
-		bank_account_branch: DF.ReadOnly | None
+		bank_account_branch: DF.Literal["C\u1eeda h\u00e0ng HCM", "C\u1eeda h\u00e0ng C\u1ea7n Th\u01a1", "C\u1eeda h\u00e0ng H\u00e0 N\u1ed9i"]
 		bank_account_no: DF.ReadOnly | None
 		bank_transactions: DF.Table[PaymentEntryBankTransaction]
 		base_in_words: DF.SmallText | None

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -153,6 +153,7 @@ class PaymentEntry(AccountsController):
 		total_order_amount: DF.Currency
 		total_taxes_and_charges: DF.Currency
 		unallocated_amount: DF.Currency
+		verified_by: DF.Link | None
 	# end: auto-generated types
 	from typing import TYPE_CHECKING
 
@@ -2045,6 +2046,25 @@ class PaymentEntry(AccountsController):
 			return
 
 		frappe.response["matched_payment_requests"] = matched_payment_requests
+
+	@frappe.whitelist()
+	def verify_payment(self):
+		"""Verify payment entry after bank transaction matching"""
+		if not self.bank_transactions or len(self.bank_transactions) == 0:
+			frappe.throw(_("Cannot verify: Payment Entry must have at least one Bank Transaction"))
+		has_sales_order = any(ref.reference_doctype == "Sales Order" for ref in self.references)
+		if not has_sales_order:
+			frappe.throw(_("Cannot verify: Payment Entry must have at least one Sales Order reference"))
+
+		if self.payment_order_status == "Success":
+			frappe.throw(_("Cannot verify: Payment has already been marked as Success"))
+
+		if self.payment_order_status == "Pending":
+			self.payment_order_status = "Success"
+		self.verified_by = frappe.session.user
+		self.save()
+
+		frappe.msgprint(_("Payment Entry verified successfully"))
 
 	@frappe.whitelist()
 	def allocate_amount_to_references(self, paid_amount, paid_amount_change, allocate_payment_amount):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -62,6 +62,98 @@ class InvalidPaymentEntry(ValidationError):
 
 
 class PaymentEntry(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from erpnext.accounts.doctype.advance_taxes_and_charges.advance_taxes_and_charges import AdvanceTaxesandCharges
+		from erpnext.accounts.doctype.payment_entry_bank_transaction.payment_entry_bank_transaction import PaymentEntryBankTransaction
+		from erpnext.accounts.doctype.payment_entry_deduction.payment_entry_deduction import PaymentEntryDeduction
+		from erpnext.accounts.doctype.payment_entry_reference.payment_entry_reference import PaymentEntryReference
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		apply_tax_withholding_amount: DF.Check
+		auto_repeat: DF.Link | None
+		bank: DF.ReadOnly | None
+		bank_account: DF.Link | None
+		bank_account_branch: DF.ReadOnly | None
+		bank_account_no: DF.ReadOnly | None
+		bank_transactions: DF.Table[PaymentEntryBankTransaction]
+		base_in_words: DF.SmallText | None
+		base_paid_amount: DF.Currency
+		base_paid_amount_after_tax: DF.Currency
+		base_received_amount: DF.Currency
+		base_received_amount_after_tax: DF.Currency
+		base_total_allocated_amount: DF.Currency
+		base_total_taxes_and_charges: DF.Currency
+		book_advance_payments_in_separate_party_account: DF.Check
+		clearance_date: DF.Date | None
+		company: DF.Link | None
+		contact_email: DF.Data | None
+		contact_person: DF.Link | None
+		cost_center: DF.Link | None
+		created_by_display: DF.Link | None
+		custom_remarks: DF.Check
+		custom_transaction_id: DF.Data | None
+		custom_transfer_note: DF.SmallText | None
+		custom_transfer_status: DF.Literal["", "pending", "success", "cancel"]
+		deductions: DF.Table[PaymentEntryDeduction]
+		difference_amount: DF.Currency
+		in_words: DF.SmallText | None
+		is_opening: DF.Literal["No", "Yes"]
+		letter_head: DF.Link | None
+		misa_sync_error_msg: DF.Data | None
+		misa_sync_guid: DF.Data | None
+		misa_synced: DF.Check
+		misa_synced_at: DF.Datetime | None
+		mode_of_payment: DF.Link | None
+		name_display: DF.Data | None
+		naming_series: DF.Literal["ACC-PAY-.YYYY.-"]
+		paid_amount: DF.Currency
+		paid_amount_after_tax: DF.Currency
+		paid_from: DF.Link | None
+		paid_from_account_balance: DF.Currency
+		paid_from_account_currency: DF.Link | None
+		paid_from_account_type: DF.Data | None
+		paid_to: DF.Link | None
+		paid_to_account_balance: DF.Currency
+		paid_to_account_currency: DF.Link | None
+		paid_to_account_type: DF.Data | None
+		party: DF.DynamicLink | None
+		party_balance: DF.Currency
+		party_bank_account: DF.Link | None
+		party_name: DF.Data | None
+		party_type: DF.Link | None
+		payment_order: DF.Link | None
+		payment_order_status: DF.Literal["Pending", "Success", "Cancel"]
+		payment_type: DF.Literal["Receive", "Pay", "Internal Transfer"]
+		posting_date: DF.Date
+		print_heading: DF.Link | None
+		project: DF.Link | None
+		purchase_taxes_and_charges_template: DF.Link | None
+		qr_url: DF.Data | None
+		received_amount: DF.Currency
+		received_amount_after_tax: DF.Currency
+		reconcile_on_advance_payment_date: DF.Check
+		reference_date: DF.Date | None
+		reference_no: DF.Data | None
+		references: DF.Table[PaymentEntryReference]
+		remarks: DF.SmallText | None
+		sales_taxes_and_charges_template: DF.Link | None
+		source_exchange_rate: DF.Float
+		status: DF.Literal["", "Draft", "Submitted", "Cancelled"]
+		target_exchange_rate: DF.Float
+		tax_withholding_category: DF.Link | None
+		taxes: DF.Table[AdvanceTaxesandCharges]
+		title: DF.Data | None
+		total_allocated_amount: DF.Currency
+		total_order_amount: DF.Currency
+		total_taxes_and_charges: DF.Currency
+		unallocated_amount: DF.Currency
+	# end: auto-generated types
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
@@ -95,6 +187,8 @@ class PaymentEntry(AccountsController):
 			self.party_account_currency = self.paid_to_account_currency
 
 	def validate(self):
+		self.set_created_by_display()
+		self.set_total_order_amount()
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
@@ -120,6 +214,55 @@ class PaymentEntry(AccountsController):
 		self.set_tax_withholding()
 		self.set_status()
 		self.set_total_in_words()
+
+	def onload(self):
+		self.set_created_by_display()
+		self.set_total_order_amount()
+		self.load_bank_transactions()
+		if self.name:
+			self.name_display = self.name
+
+	def load_bank_transactions(self):
+		"""Fetch and populate linked Bank Transactions"""
+		if not self.name:
+			return
+
+		self.bank_transactions = []
+		linked_transactions = frappe.db.sql("""
+			SELECT
+				btp.parent as bank_transaction,
+				bt.date,
+				btp.allocated_amount,
+				btp.clearance_date
+			FROM `tabBank Transaction Payments` btp
+			INNER JOIN `tabBank Transaction` bt ON bt.name = btp.parent
+			WHERE btp.payment_entry = %s
+			ORDER BY bt.date DESC
+		""", (self.name,), as_dict=True)
+
+		for row in linked_transactions:
+			self.append("bank_transactions", row)
+
+	def set_created_by_display(self):
+		if self.owner:
+			self.created_by_display = self.owner
+
+	def set_total_order_amount(self):
+		"""Fetch grand_total from linked Sales Order if exists"""
+		self.total_order_amount = 0
+
+		if not self.references:
+			return
+
+		for ref in self.references:
+			if ref.reference_doctype == "Sales Order" and ref.reference_name:
+				try:
+					grand_total = frappe.db.get_value("Sales Order", ref.reference_name, "grand_total")
+					if grand_total:
+						self.total_order_amount = grand_total
+						break
+				except Exception:
+					pass
 
 	def before_save(self):
 		self.set_matched_unset_payment_requests_to_response()

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3051,6 +3051,14 @@ def get_reference_details(
 			"payment_type": payment_type,
 		}
 	)
+
+	if reference_doctype == "Sales Order":
+		res.update({
+			"balance": flt(ref_doc.get("balance")),
+			"order_number": ref_doc.get("order_number")
+		})
+
+
 	if account:
 		res.update({"account": account})
 	return res
@@ -3806,3 +3814,37 @@ def get_bank_transactions(doctype, txt, searchfield, start, page_len, filters):
 			"page_len": page_len,
 		},
 	)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, filters):
+	"""Custom query to search Sales Orders by name and order_number"""
+	return frappe.db.sql(
+		"""
+		SELECT name, order_number, customer_name
+		FROM `tabSales Order`
+		WHERE (
+			name LIKE %(txt)s
+			OR order_number LIKE %(txt)s
+			OR customer_name Like %(txt)s
+		)
+		AND company = %(company)s
+		ORDER BY
+			CASE
+				WHEN name LIKE %(txt)s THEN 0
+				WHEN order_number LIKE %(txt)s THEN 1
+				ELSE 2
+			END,
+			modified DESC
+		LIMIT %(page_len)s OFFSET %(start)s
+		""",
+		{
+			"txt": f"%{txt}%",
+			"company": filters.get("company"),
+			"start": start,
+			"page_len": page_len,
+		},
+	)
+
+

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -528,9 +528,10 @@ class PaymentEntry(AccountsController):
 			latest = latest.get(d.payment_term) or latest.get(None)
 			# The reference has already been fully paid
 			if not latest:
-				frappe.throw(
-					_("{0} {1} has already been fully paid.").format(_(d.reference_doctype), d.reference_name)
-				)
+				return
+				# frappe.throw(
+				# 	_("{0} {1} has already been fully paid.").format(_(d.reference_doctype), d.reference_name)
+				# )
 			# The reference has already been partly paid
 			elif (
 				latest.outstanding_amount < latest.invoice_amount
@@ -1369,12 +1370,13 @@ class PaymentEntry(AccountsController):
 			self.title = self.paid_from + " - " + self.paid_to
 
 	def validate_transaction_reference(self):
-		bank_account = self.paid_to if self.payment_type == "Receive" else self.paid_from
-		bank_account_type = frappe.get_cached_value("Account", bank_account, "account_type")
-
-		if bank_account_type == "Bank":
-			if not self.reference_no or not self.reference_date:
-				frappe.throw(_("Reference No and Reference Date is mandatory for Bank transaction"))
+		# Removed Bank-only validation - reference_no and reference_date are now always optional
+		pass
+		# bank_account = self.paid_to if self.payment_type == "Receive" else self.paid_from
+		# bank_account_type = frappe.get_cached_value("Account", bank_account, "account_type")
+		# if bank_account_type == "Bank":
+		# 	if not self.reference_no or not self.reference_date:
+		# 		frappe.throw(_("Reference No and Reference Date is mandatory for Bank transaction"))
 
 	def set_remarks(self):
 		if self.custom_remarks:

--- a/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
+++ b/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
@@ -8,7 +8,7 @@
   "bank_transaction",
   "date",
   "allocated_amount",
-  "clearance_date"
+  "sepay_transaction_content"
  ],
  "fields": [
   {
@@ -16,30 +16,27 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Bank Transaction",
-   "options": "Bank Transaction",
-   "read_only": 1
+   "options": "Bank Transaction"
   },
   {
    "fieldname": "date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Date",
-   "read_only": 1
+   "label": "Date"
   },
   {
    "fieldname": "allocated_amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Allocated Amount",
-   "read_only": 1
+   "label": "Allocated Amount"
   },
   {
-   "fieldname": "clearance_date",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Clearance Date",
+   "fieldname": "sepay_transaction_content",
+   "fieldtype": "Small Text",
+   "label": "Transaction Content",
    "read_only": 1
   }
+
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
@@ -49,7 +46,56 @@
  "module": "Accounts",
  "name": "Payment Entry Bank Transaction",
  "owner": "Administrator",
- "permissions": [],
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "import": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+ {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "import": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "import": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
+++ b/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "creation": "2025-12-02 10:50:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "bank_transaction",
+  "date",
+  "allocated_amount",
+  "clearance_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "bank_transaction",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Bank Transaction",
+   "options": "Bank Transaction",
+   "read_only": 1
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "allocated_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Allocated Amount",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clearance_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Clearance Date",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-12-02 10:50:00.000000",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Payment Entry Bank Transaction",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.py
+++ b/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PaymentEntryBankTransaction(Document):
+	pass

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -7,6 +7,7 @@
  "field_order": [
   "reference_doctype",
   "reference_name",
+  "order_number",
   "due_date",
   "bill_no",
   "payment_term",
@@ -17,6 +18,7 @@
   "column_break_4",
   "total_amount",
   "outstanding_amount",
+  "balance",
   "allocated_amount",
   "exchange_rate",
   "exchange_gain_loss",
@@ -26,10 +28,9 @@
  ],
  "fields": [
   {
-   "columns": 2,
+   "columns": 1,
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Type",
    "options": "DocType",
    "reqd": 1,
@@ -45,6 +46,16 @@
    "options": "reference_doctype",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "columns": 2,
+   "depends_on": "eval:doc.reference_doctype=='Sales Order'",
+   "fetch_from": "reference_name.order_number",
+   "fieldname": "order_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Order Number",
+   "read_only": 1
   },
   {
    "fieldname": "due_date",
@@ -68,7 +79,7 @@
    "fieldname": "total_amount",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Grand Total",
+   "label": "Total Amount",
    "print_hide": 1,
    "read_only": 1
   },
@@ -76,8 +87,16 @@
    "columns": 2,
    "fieldname": "outstanding_amount",
    "fieldtype": "Float",
-   "in_list_view": 1,
    "label": "Outstanding",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "depends_on": "eval:doc.reference_doctype=='Sales Order'",
+   "fieldname": "balance",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Balance",
    "read_only": 1
   },
   {


### PR DESCRIPTION
### **User description**
#### Changes:
- Make it easier for sales person to use
- Added bank transactions link to Payment Entry (PE)

#### Proof/ Images
- Please refer to the ticket link below

#### Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=790cda8f-eae7-41f7-82a6-344eeedcc56e&suite_entity_num=t116681)


___

### **PR Type**
Enhancement


___

### **Description**
- Added bank transactions child table to Payment Entry for linking bank transactions

- Implemented dynamic bank branch logic based on payment mode (Wire Transfer/QR)

- Added new display fields: created_by_display, total_order_amount, name_display

- Bypassed mandatory validation for reference_no and reference_date fields

- Reorganized UI layout with hidden sections and reordered field display

- Added MISA sync tracking fields for integration purposes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PE["Payment Entry"] -->|load_bank_transactions| BT["Bank Transactions<br/>Child Table"]
  PE -->|update_bank_branch_logic| BAB["Bank Account<br/>Branch Field"]
  PE -->|set_created_by_display| CBD["Created By<br/>Display"]
  PE -->|set_total_order_amount| TOA["Total Order<br/>Amount"]
  MOP["Mode of Payment"] -->|Wire Transfer/QR| BAB
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.py</strong><dd><code>Added bank transactions loading and display field initialization</code></dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.py

<ul><li>Added auto-generated type hints for all Payment Entry fields including <br>new <code>bank_transactions</code> table<br> <li> Implemented <code>load_bank_transactions()</code> method to fetch and populate <br>linked bank transactions from Bank Transaction Payments<br> <li> Added <code>set_created_by_display()</code> method to populate created_by_display <br>field with document owner<br> <li> Added <code>set_total_order_amount()</code> method to fetch grand_total from linked <br>Sales Orders<br> <li> Added <code>onload()</code> hook to initialize display fields and load bank <br>transactions<br> <li> Bypassed validation error for fully paid invoices by returning early <br>instead of throwing exception<br> <li> Removed mandatory validation for reference_no and reference_date in <br><code>validate_transaction_reference()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/186/files#diff-a7f7fdc2db51fe011675d0f9a7fb593cd56720070ddea9b391b6c3f816fe140e">+154/-9</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry_bank_transaction.py</strong><dd><code>New child table doctype for bank transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.py

<ul><li>Created new child table doctype for Payment Entry Bank Transaction<br> <li> Minimal implementation with Document base class</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/186/files#diff-f721f1f40490539cafa0b15c902c6f73c49115cb44aea368a44a67d5b87eab28">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.js</strong><dd><code>Added dynamic bank branch field logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.js

<ul><li>Added <code>update_bank_branch_logic()</code> function to dynamically set <br>bank_account_branch field properties based on mode_of_payment<br> <li> For Wire Transfer and QR modes: set field to read-only and populate <br>with account_type value<br> <li> For other modes: allow user selection from three branch options (HCM, <br>Can Tho, Ha Noi)<br> <li> Integrated branch logic into refresh, mode_of_payment change, and <br>bank_account change events<br> <li> Set created_by_display to current user on form creation</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/186/files#diff-945a4747de34888d5385f1d4f57527e391be523af96a104c2a49792206c89726">+37/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.json</strong><dd><code>Reorganized Payment Entry form layout and added new fields</code></dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.json

<ul><li>Reorganized field_order: moved name_display, created_by_display to <br>top; added bank_transactions_section<br> <li> Added new fields: name_display, created_by_display, <br>bank_account_branch, total_order_amount, bank_transactions<br> <li> Added MISA sync tracking fields: misa_synced, misa_sync_guid, <br>misa_synced_at, misa_sync_error_msg<br> <li> Hidden multiple sections and fields: payment_accounts_section, <br>deductions_or_loss_section, transaction_references, <br>accounting_dimensions_section, taxes_and_charges_section<br> <li> Hidden individual fields: company, cost_center, party_name, <br>contact_person, contact_email, paid_to, paid_to_account_currency, <br>received_amount, target_exchange_rate, base_received_amount, project, <br>party_bank_account<br> <li> Removed mandatory requirements from: paid_from, <br>paid_from_account_currency, paid_to, paid_to_account_currency, <br>received_amount, target_exchange_rate, base_received_amount, <br>source_exchange_rate, base_paid_amount<br> <li> Removed mandatory_depends_on conditions for reference_no and <br>reference_date<br> <li> Updated payment_order_status field: changed options from <br>"Initiated\nPayment Ordered" to "Pending\nSuccess\nCancel", made it <br>bold with default "Pending"<br> <li> Made custom fields read-only: custom_transaction_id, <br>custom_transfer_note, custom_transfer_status, qr_url<br> <li> Updated field labels: custom_transaction_id → "QR Transaction ID", <br>custom_transfer_note → "Transfer Note", custom_transfer_status → <br>"Transfer Status"<br> <li> Added bank_transactions table field with read-only access<br> <li> Updated modified timestamp to 2025-12-02</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/186/files#diff-1cb8987729b5486a8ec30e408fc0ba91f343f44c8248a10835ce3bea88ce214d">+163/-47</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry_bank_transaction.json</strong><dd><code>New child table doctype configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json

<ul><li>Created new child table doctype configuration for Payment Entry Bank <br>Transaction<br> <li> Defined four fields: bank_transaction (Link), date (Date), <br>allocated_amount (Currency), clearance_date (Date)<br> <li> All fields set to read-only and included in list view<br> <li> Configured as editable grid with InnoDB engine</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/186/files#diff-83d10b38522615c8ed2e0fff4d698bfb2785673f523e797f2f6541b56d1884f1">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

