### PR TITLE
Feature/accounts/adding more required business field

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -246,7 +246,8 @@ frappe.ui.form.on("Payment Entry", {
 				return {
 					query: "erpnext.accounts.doctype.payment_entry.payment_entry.get_sales_orders_for_payment",
 					filters: {
-						company: frm.doc.company
+						company: frm.doc.company,
+						customer: frm.doc.party
 					}
 				};
 			}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -325,7 +325,8 @@ frappe.ui.form.on("Payment Entry", {
 		if (
 			!frm.is_new() &&
 			!frm.doc.verified_by &&
-			(frm.doc.payment_order_status === "Draft" || frm.doc.payment_order_status === "Pending" || !frm.doc.payment_order_status)
+			(frm.doc.payment_order_status === "Draft" || frm.doc.payment_order_status === "Pending") &&
+			(frappe.user.has_role("Accounts User") || frappe.user.has_role("Accounts Manager"))
 		) {
 			frm.add_custom_button(__("Verify"), () => {
 				let skip_bank_check = ["Cash", "COD"].includes(frm.doc.mode_of_payment);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -40,7 +40,9 @@ frappe.ui.form.on("Payment Entry", {
 		});
 
 		if (frm.is_new()) {
-			frm.set_value("created_by_display", frappe.session.user);
+			if (!frm.doc.created_by_display) {
+				frm.set_value("created_by_display", frappe.session.user);
+			}
 			set_default_party_type(frm);
 		}
 	},
@@ -321,9 +323,9 @@ frappe.ui.form.on("Payment Entry", {
 
 		// Add Verify button
 		if (
+			!frm.is_new() &&
 			!frm.doc.verified_by &&
-			frm.doc.payment_order_status !== "Success" &&
-			frm.doc.payment_order_status !== "Cancel"
+			(frm.doc.payment_order_status === "Draft" || frm.doc.payment_order_status === "Pending" || !frm.doc.payment_order_status)
 		) {
 			frm.add_custom_button(__("Verify"), () => {
 				let skip_bank_check = ["Cash", "COD"].includes(frm.doc.mode_of_payment);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -2011,12 +2011,15 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 	bank_transaction: function(frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		if (row.bank_transaction) {
-			frappe.db.get_value("Bank Transaction", row.bank_transaction, ["date", "deposit", "sepay_transaction_content"], (r) => {
+			frappe.db.get_value("Bank Transaction", row.bank_transaction, ["date", "deposit", "withdrawal", "sepay_transaction_content", "sepay_transaction_date"], (r) => {
 				if (r) {
 					frappe.model.set_value(cdt, cdn, "date", r.date);
 					let amount = r.deposit || r.withdrawal || 0;
 					frappe.model.set_value(cdt, cdn, "allocated_amount", amount);
 					frappe.model.set_value(cdt, cdn, "sepay_transaction_content", r.sepay_transaction_content);
+					if (r.sepay_transaction_date) {
+						frm.set_value("payment_date", r.sepay_transaction_date);
+					}
 				}
 			});
 		}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -211,7 +211,8 @@
    "in_list_view": 1,
    "label": "Transfer Status",
    "options": "\npending\nsuccess\ncancel",
-   "read_only": 1
+   "read_only": 1,
+   "hidden": 1
   },
   {
    "fieldname": "qr_url",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -18,6 +18,7 @@
   "verified_by",
   "column_break_5",
   "posting_date",
+  "payment_date",
   "mode_of_payment",
   "company",
   "bank_account",
@@ -158,6 +159,12 @@
    "in_list_view": 1,
    "label": "Posting Date",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "payment_date",
+   "fieldtype": "Date",
+   "label": "Payment Date"
   },
   {
    "fieldname": "company",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3874,6 +3874,3 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 			"page_len": page_len,
 		},
 	)
-
-
-

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3792,12 +3792,16 @@ def get_bank_transactions(doctype, txt, searchfield, start, page_len, filters):
 	"""Custom query to search Bank Transactions by name, bank_account, and sepay_transaction_content"""
 	return frappe.db.sql(
 		"""
-		SELECT name, bank_account, sepay_transaction_content
+		SELECT name, sepay_amount_in, bank_account, sepay_transaction_content
 		FROM `tabBank Transaction`
 		WHERE (
 			name LIKE %(txt)s
 			OR bank_account LIKE %(txt)s
 			OR sepay_transaction_content LIKE %(txt)s
+			OR sepay_reference_number LIKE %(txt)s
+			OR sepay_order_description LIKE %(txt)s
+			OR sepay_order_number LIKE %(txt)s
+			OR sepay_amount_in LIKE %(txt)s
 		)
 		{conditions}
 		ORDER BY
@@ -3830,6 +3834,7 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 			OR customer_name Like %(txt)s
 		)
 		AND company = %(company)s
+		AND customer = %(customer)s
 		ORDER BY
 			CASE
 				WHEN name LIKE %(txt)s THEN 0
@@ -3842,9 +3847,11 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 		{
 			"txt": f"%{txt}%",
 			"company": filters.get("company"),
+			"customer": filters.get("customer"),
 			"start": start,
 			"page_len": page_len,
 		},
 	)
+
 
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -271,6 +271,27 @@ class PaymentEntry(AccountsController):
 	def before_save(self):
 		self.set_matched_unset_payment_requests_to_response()
 
+	def on_update(self):
+		self.sync_bank_transaction_payments()
+
+	def sync_bank_transaction_payments(self):
+		for bt_row in self.bank_transactions:
+			if bt_row.bank_transaction:
+				bank_transaction = frappe.get_doc("Bank Transaction", bt_row.bank_transaction)
+				existing = any(
+					pe.payment_document == "Payment Entry" and pe.payment_entry == self.name
+					for pe in bank_transaction.payment_entries
+				)
+
+				if not existing:
+					bank_transaction.append("payment_entries", {
+						"payment_document": "Payment Entry",
+						"payment_entry": self.name,
+						"allocated_amount": bt_row.allocated_amount
+					})
+					bank_transaction.save(ignore_permissions=True)
+
+
 	def on_submit(self):
 		if self.difference_amount:
 			frappe.throw(_("Difference Amount must be zero"))

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -248,8 +248,8 @@ class PaymentEntry(AccountsController):
 			self.append("bank_transactions", row)
 
 	def set_created_by_display(self):
-		if self.owner:
-			self.created_by_display = self.owner
+		if not self.created_by_display:
+			self.created_by_display = frappe.session.user
 
 	def set_total_order_amount(self):
 		"""Fetch grand_total from linked Sales Order if exists"""
@@ -3055,7 +3055,8 @@ def get_reference_details(
 	if reference_doctype == "Sales Order":
 		res.update({
 			"balance": flt(ref_doc.get("balance")),
-			"order_number": ref_doc.get("order_number")
+			"order_number": ref_doc.get("order_number"),
+			"split_order_group_name": ref_doc.get("split_order_group_name")
 		})
 
 

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -8,6 +8,7 @@
   "reference_doctype",
   "reference_name",
   "order_number",
+  "split_order_group_name",
   "due_date",
   "bill_no",
   "payment_term",
@@ -48,13 +49,23 @@
    "search_index": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fetch_from": "reference_name.order_number",
    "fieldname": "order_number",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Order Number",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "depends_on": "eval:doc.reference_doctype=='Sales Order'",
+   "fetch_from": "reference_name.split_order_group_name",
+   "fieldname": "split_order_group_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Group Order",
    "read_only": 1
   },
   {

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -38,7 +38,7 @@
    "search_index": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "fieldname": "reference_name",
    "fieldtype": "Dynamic Link",
    "in_global_search": 1,
@@ -49,7 +49,7 @@
    "search_index": 1
   },
   {
-   "columns": 1,
+   "columns": 2,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fetch_from": "reference_name.order_number",
    "fieldname": "order_number",
@@ -59,7 +59,7 @@
    "read_only": 1
   },
   {
-   "columns": 1,
+   "columns": 2,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fetch_from": "reference_name.split_order_group_name",
    "fieldname": "split_order_group_name",
@@ -102,7 +102,7 @@
    "read_only": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fieldname": "balance",
    "fieldtype": "Currency",
@@ -111,7 +111,7 @@
    "read_only": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "fieldname": "allocated_amount",
    "fieldtype": "Float",
    "in_list_view": 1,


### PR DESCRIPTION
### **User description**
#### Changes
- Verify button
  - Only Accountant User & Manager able to user
  - Hide when create new Payment Entry (PE)
- Added Group order column to PE's references Sales Order (SO)
- When look-up for SO for Payment Entry references, we need also filter based on current Party ( Customer )
- When adding SO, we will filter with Party
- Allow create PE for another user
- Added `Payment Date` to PE

##### Proof
<img width="1064" height="321" alt="Screenshot 2025-12-05 at 08 59 27" src="https://github.com/user-attachments/assets/0c2773fa-c91e-4dc5-9c7c-2a51e7ce2289" />

<img width="2160" height="966" alt="image" src="https://github.com/user-attachments/assets/c7d49e4f-c695-4c6b-b57e-bfc795f4f16f" />


####

___

### **PR Type**
Enhancement


___

### **Description**
- Auto-link Payment Entries to Bank Transactions on update

- Filter Sales Orders by customer and add Group Order column

- Restrict Verify button to Accountants and Managers only

- Improve Bank Transaction search with additional fields

- Fix created_by_display to use session user instead of owner


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PE["Payment Entry"] -->|on_update| sync["Sync Bank Transaction Payments"]
  sync -->|append| BT["Bank Transaction.payment_entries"]
  PE -->|filter SO| SO["Sales Orders by Customer"]
  SO -->|display| group["Group Order Column"]
  PE -->|verify button| access{{"Accountants/Managers Only"}}
  access -->|Draft/Pending| verify["Verify Action"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.py</strong><dd><code>Auto-sync PE to BT and enhance search/filter logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.py

<ul><li>Added <code>on_update()</code> hook to sync Payment Entries to Bank Transaction's <br><code>payment_entries</code> child table<br> <li> Fixed <code>set_created_by_display()</code> to use <code>frappe.session.user</code> instead of <br><code>self.owner</code><br> <li> Enhanced <code>get_reference_details()</code> to include <code>split_order_group_name</code> for <br>Sales Order references<br> <li> Updated <code>get_bank_transactions()</code> query to search by <code>sepay_amount_in</code>, <br><code>sepay_reference_number</code>, <code>sepay_order_description</code>, and <br><code>sepay_order_number</code><br> <li> Modified <code>get_sales_orders_for_payment()</code> to filter by customer in <br>addition to company</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/187/files#diff-a7f7fdc2db51fe011675d0f9a7fb593cd56720070ddea9b391b6c3f816fe140e">+33/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.js</strong><dd><code>Restrict verify button and improve customer filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.js

<ul><li>Updated <code>created_by_display</code> initialization to check if already set <br>before assigning session user<br> <li> Added <code>customer</code> filter parameter when querying Sales Orders for payment <br>references<br> <li> Enhanced Verify button visibility logic to only show for non-new <br>documents with Draft/Pending status and for Accounts User/Manager <br>roles</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/187/files#diff-945a4747de34888d5385f1d4f57527e391be523af96a104c2a49792206c89726">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry_reference.json</strong><dd><code>Add Group Order column to Payment Entry Reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json

<ul><li>Added new <code>split_order_group_name</code> field to Payment Entry Reference <br>doctype<br> <li> Field fetches from <code>reference_name.split_order_group_name</code> for Sales <br>Order references<br> <li> Configured as read-only, in-list-view, and dependent on Sales Order <br>reference type<br> <li> Adjusted <code>order_number</code> column width from 2 to 1 to accommodate new <br>field</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/187/files#diff-22d3bb3c8d41f7f19ef7351db108cc97e1ef912151537e5e34c09c33f5302891">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

