### PR TITLE
Feature/accounts/auto verify bank transaction

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -82,7 +82,6 @@
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
-   "in_standard_filter": 1,
    "label": "Status",
    "options": "\nPending\nSettled\nUnreconciled\nReconciled\nCancelled"
   },
@@ -97,7 +96,6 @@
    "fetch_from": "bank_account.company",
    "fieldname": "company",
    "fieldtype": "Link",
-   "in_standard_filter": 1,
    "label": "Company",
    "options": "Company",
    "read_only": 1
@@ -254,21 +252,25 @@
   {
    "fieldname": "sepay_id",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Sepay ID"
   },
   {
    "fieldname": "sepay_order_number",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Sepay Order Number"
   },
   {
    "fieldname": "sepay_order_description",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Sepay Order Description"
   },
   {
    "fieldname": "sepay_bank_brand_name",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Sepay Bank Brand Name"
   },
   {
@@ -308,6 +310,7 @@
   {
    "fieldname": "sepay_reference_number",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Sepay Reference Number"
   },
   {

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -117,6 +117,40 @@ class BankTransaction(Document):
 
 			self.delink_payment_entry(old_pe)
 
+	def on_update(self):
+		self.sync_payment_entry_bank_transactions()
+
+	def sync_payment_entry_bank_transactions(self):
+		if self.flags.get("updating_linked_bank_transaction"):
+			return
+
+		for pe_row in self.payment_entries:
+			if pe_row.payment_document == "Payment Entry" and pe_row.payment_entry:
+				try:
+					payment_entry = frappe.get_doc("Payment Entry", pe_row.payment_entry)
+					existing = any(
+						bt.bank_transaction == self.name
+						for bt in payment_entry.bank_transactions
+					)
+
+					if not existing:
+						payment_entry.flags.updating_from_bank_transaction = True
+						payment_entry.append("bank_transactions", {
+							"bank_transaction": self.name,
+							"allocated_amount": pe_row.allocated_amount,
+							"date": self.date,
+							"sepay_transaction_content": self.sepay_transaction_content,
+							"sepay_order_number": self.sepay_order_number,
+							"sepay_order_description": self.sepay_order_description,
+							"sepay_reference_number": self.sepay_reference_number
+						})
+						if self.sepay_transaction_date:
+							payment_entry.payment_date = self.sepay_transaction_date
+
+						payment_entry.save(ignore_permissions=True)
+				except Exception as e:
+					frappe.log_error(f"Error syncing Bank Transaction to Payment Entry: {str(e)}")
+
 	def before_submit(self):
 		self.allocate_payment_entries()
 		self.set_status()

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -142,7 +142,9 @@ class BankTransaction(Document):
 							"sepay_transaction_content": self.sepay_transaction_content,
 							"sepay_order_number": self.sepay_order_number,
 							"sepay_order_description": self.sepay_order_description,
-							"sepay_reference_number": self.sepay_reference_number
+							"sepay_reference_number": self.sepay_reference_number,
+							"sepay_id": self.sepay_id,
+							"auto_updated": 1
 						})
 						if self.sepay_transaction_date:
 							payment_entry.payment_date = self.sepay_transaction_date

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "mode_of_payment",
+  "payment_code",
   "enabled",
   "type",
   "accounts"
@@ -42,13 +43,20 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "fieldname": "payment_code",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Payment Code"
   }
  ],
  "icon": "fa fa-credit-card",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-09-18 17:57:23.835236",
+ "modified": "2025-12-09 09:25:56.703147",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Mode of Payment",
@@ -71,7 +79,9 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py
@@ -14,15 +14,13 @@ class ModeofPayment(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from erpnext.accounts.doctype.mode_of_payment_account.mode_of_payment_account import ModeofPaymentAccount
 		from frappe.types import DF
-
-		from erpnext.accounts.doctype.mode_of_payment_account.mode_of_payment_account import (
-			ModeofPaymentAccount,
-		)
 
 		accounts: DF.Table[ModeofPaymentAccount]
 		enabled: DF.Check
 		mode_of_payment: DF.Data
+		payment_code: DF.Data | None
 		type: DF.Literal["Cash", "Bank", "General", "Phone"]
 	# end: auto-generated types
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -2019,7 +2019,8 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 				"sepay_transaction_date",
 				"sepay_order_number",
 				"sepay_order_description",
-				"sepay_reference_number"
+				"sepay_reference_number",
+				"sepay_id",
 			], (r) => {
 				if (r) {
 					frappe.model.set_value(cdt, cdn, "date", r.date);
@@ -2029,6 +2030,7 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 					frappe.model.set_value(cdt, cdn, "sepay_order_number", r.sepay_order_number);
 					frappe.model.set_value(cdt, cdn, "sepay_order_description", r.sepay_order_description);
 					frappe.model.set_value(cdt, cdn, "sepay_reference_number", r.sepay_reference_number);
+					frappe.model.set_value(cdt, cdn, "sepay_id", r.sepay_id);
 					if (r.sepay_transaction_date) {
 						frm.set_value("payment_date", r.sepay_transaction_date);
 					}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -256,8 +256,21 @@ frappe.ui.form.on("Payment Entry", {
 		});
 	},
 
+	update_gateway_options: function(frm) {
+		if (frm.doc.mode_of_payment === "POS") {
+			frm.set_df_property("gateway", "options", ["Payoo", "Vietcombank"]);
+			frm.set_value("gateway", "Payoo");
+		} else if (frm.doc.mode_of_payment === "Payment Link") {
+			frm.set_df_property("gateway", "options", ["Payoo", "ZaloPay"]);
+			frm.set_value("gateway", "Payoo");
+		} else {
+			frm.set_df_property("gateway", "options", [""]);
+			frm.set_value("gateway", "");
+		}
+	},
+
 	update_bank_branch_logic: function (frm) {
-		if (["Wire Transfer", "QR"].includes(frm.doc.mode_of_payment)) {
+		if (["Wire Transfer", "QR", "Payment Link", "POS", "Cash On Delivery"].includes(frm.doc.mode_of_payment)) {
 			frm.set_df_property("bank_account_branch", "read_only", 1);
 			if (frm.doc.bank_account) {
 				frappe.db.get_value("Bank Account", frm.doc.bank_account, "account_type", (r) => {
@@ -280,6 +293,7 @@ frappe.ui.form.on("Payment Entry", {
 	},
 
 	refresh: function (frm) {
+		frm.events.update_gateway_options(frm);
 		frm.events.update_bank_branch_logic(frm);
 		erpnext.hide_company(frm);
 		frm.events.hide_unhide_fields(frm);
@@ -554,6 +568,8 @@ frappe.ui.form.on("Payment Entry", {
 	},
 
 	mode_of_payment: function (frm) {
+		frm.set_value("gateway", "");
+		frm.events.update_gateway_options(frm);
 		erpnext.accounts.pos.get_payment_mode_account(frm, frm.doc.mode_of_payment, function (account) {
 			let payment_account_field = frm.doc.payment_type == "Receive" ? "paid_to" : "paid_from";
 			frm.set_value(payment_account_field, account);
@@ -1442,6 +1458,7 @@ frappe.ui.form.on("Payment Entry", {
 	},
 
 	bank_account: function (frm) {
+		frm.events.update_bank_branch_logic(frm);
 		const field = frm.doc.payment_type == "Pay" ? "paid_from" : "paid_to";
 		if (frm.doc.bank_account && ["Pay", "Receive"].includes(frm.doc.payment_type)) {
 			frappe.call({

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -2011,12 +2011,24 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 	bank_transaction: function(frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		if (row.bank_transaction) {
-			frappe.db.get_value("Bank Transaction", row.bank_transaction, ["date", "deposit", "withdrawal", "sepay_transaction_content", "sepay_transaction_date"], (r) => {
+			frappe.db.get_value("Bank Transaction", row.bank_transaction, [
+				"date",
+				"deposit",
+				"withdrawal",
+				"sepay_transaction_content",
+				"sepay_transaction_date",
+				"sepay_order_number",
+				"sepay_order_description",
+				"sepay_reference_number"
+			], (r) => {
 				if (r) {
 					frappe.model.set_value(cdt, cdn, "date", r.date);
 					let amount = r.deposit || r.withdrawal || 0;
 					frappe.model.set_value(cdt, cdn, "allocated_amount", amount);
 					frappe.model.set_value(cdt, cdn, "sepay_transaction_content", r.sepay_transaction_content);
+					frappe.model.set_value(cdt, cdn, "sepay_order_number", r.sepay_order_number);
+					frappe.model.set_value(cdt, cdn, "sepay_order_description", r.sepay_order_description);
+					frappe.model.set_value(cdt, cdn, "sepay_reference_number", r.sepay_reference_number);
 					if (r.sepay_transaction_date) {
 						frm.set_value("payment_date", r.sepay_transaction_date);
 					}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -3,7 +3,7 @@
  "allow_auto_repeat": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
- "creation": "2025-12-03 14:08:40.555886",
+ "creation": "2025-12-07 19:16:48.513741",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -12,17 +12,19 @@
   "type_of_payment",
   "naming_series",
   "name_display",
-  "payment_type",
-  "payment_order_status",
-  "created_by_display",
-  "verified_by",
-  "column_break_5",
-  "posting_date",
-  "payment_date",
   "mode_of_payment",
-  "company",
+  "payment_type",
+  "gateway",
   "bank_account",
   "bank_account_branch",
+  "verified_by",
+  "column_break_5",
+  "created_by_display",
+  "payment_date",
+  "posting_date",
+  "company",
+  "payment_order_status",
+  "party",
   "qr_section_break",
   "custom_transaction_id",
   "custom_transfer_status",
@@ -35,7 +37,6 @@
   "book_advance_payments_in_separate_party_account",
   "reconcile_on_advance_payment_date",
   "column_break_11",
-  "party",
   "party_bank_account",
   "contact_person",
   "contact_email",
@@ -138,8 +139,10 @@
   },
   {
    "bold": 1,
+   "default": "Receive",
    "fieldname": "payment_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Payment Type",
@@ -156,14 +159,14 @@
    "default": "Today",
    "fieldname": "posting_date",
    "fieldtype": "Date",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Posting Date",
    "reqd": 1
   },
   {
-   "depends_on": "eval:!doc.__islocal",
    "fieldname": "payment_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Payment Date"
   },
   {
@@ -192,6 +195,12 @@
    "options": "Mode of Payment"
   },
   {
+   "depends_on": "eval:in_list([\"Payment Link\", \"POS\"], doc.mode_of_payment)",
+   "fieldname": "gateway",
+   "fieldtype": "Select",
+   "label": "Gateway"
+  },
+  {
    "fieldname": "custom_transaction_id",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -208,11 +217,11 @@
   {
    "fieldname": "custom_transfer_status",
    "fieldtype": "Select",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Transfer Status",
    "options": "\npending\nsuccess\ncancel",
-   "read_only": 1,
-   "hidden": 1
+   "read_only": 1
   },
   {
    "fieldname": "qr_url",
@@ -222,15 +231,17 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:in_list([\"Receive\", \"Pay\"], doc.payment_type)",
    "fieldname": "party_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Payment From / To"
   },
   {
    "bold": 1,
+   "default": "Customer",
    "fieldname": "party_type",
    "fieldtype": "Link",
+   "hidden": 1,
    "in_standard_filter": 1,
    "label": "Party Type",
    "options": "DocType",
@@ -238,7 +249,6 @@
   },
   {
    "bold": 1,
-   "depends_on": "eval:in_list([\"Receive\", \"Pay\"], doc.payment_type) && doc.party_type",
    "fieldname": "party",
    "fieldtype": "Dynamic Link",
    "in_standard_filter": 1,
@@ -529,10 +539,10 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "bank_transactions_section",
    "fieldtype": "Section Break",
-   "label": "Bank Transactions",
-   "depends_on": "eval:!doc.__islocal"
+   "label": "Bank Transactions"
   },
   {
    "fieldname": "bank_transactions",
@@ -637,6 +647,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.mode_of_payment && doc.mode_of_payment !== \"Cash\"",
    "fieldname": "bank_account",
    "fieldtype": "Link",
    "label": "Company Bank Account",
@@ -654,6 +665,7 @@
   {
    "bold": 1,
    "default": "Pending",
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "payment_order_status",
    "fieldtype": "Select",
    "label": "Payment Status",
@@ -663,6 +675,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "accounting_dimensions_section",
    "fieldtype": "Section Break",
    "label": "Accounting Dimensions"
@@ -936,6 +949,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.mode_of_payment",
    "fieldname": "bank_account_branch",
    "fieldtype": "Select",
    "label": "Branch",
@@ -960,7 +974,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-03 14:31:30.538490",
+ "modified": "2025-12-07 20:15:10.432879",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -433,7 +433,7 @@
    "depends_on": "eval:(doc.party && doc.paid_from && doc.paid_to && doc.paid_amount && doc.received_amount)",
    "fieldname": "section_break_14",
    "fieldtype": "Section Break",
-   "label": "Reference"
+   "label": "Orders"
   },
   {
    "fieldname": "references",
@@ -913,6 +913,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "total_order_amount",
    "fieldtype": "Currency",
    "label": "Total Order Amount",
@@ -976,7 +977,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-07 20:15:10.432879",
+ "modified": "2025-12-08 16:56:44.971558",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -377,6 +377,7 @@
    "fieldtype": "Currency",
    "label": "Paid Amount",
    "options": "paid_from_account_currency",
+   "precision": "0",
    "reqd": 1
   },
   {
@@ -915,6 +916,7 @@
    "fieldname": "total_order_amount",
    "fieldtype": "Currency",
    "label": "Total Order Amount",
+   "precision": "0",
    "read_only": 1
   },
   {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -275,6 +275,9 @@ class PaymentEntry(AccountsController):
 		self.sync_bank_transaction_payments()
 
 	def sync_bank_transaction_payments(self):
+		if self.flags.get("updating_from_bank_transaction"):
+			return
+
 		for bt_row in self.bank_transactions:
 			if bt_row.bank_transaction:
 				bank_transaction = frappe.get_doc("Bank Transaction", bt_row.bank_transaction)
@@ -284,6 +287,7 @@ class PaymentEntry(AccountsController):
 				)
 
 				if not existing:
+					bank_transaction.flags.updating_linked_bank_transaction = True
 					bank_transaction.append("payment_entries", {
 						"payment_document": "Payment Entry",
 						"payment_entry": self.name,

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -102,6 +102,7 @@ class PaymentEntry(AccountsController):
 		custom_transfer_status: DF.Literal["", "pending", "success", "cancel"]
 		deductions: DF.Table[PaymentEntryDeduction]
 		difference_amount: DF.Currency
+		gateway: DF.Literal[None]
 		in_words: DF.SmallText | None
 		is_opening: DF.Literal["No", "Yes"]
 		letter_head: DF.Link | None
@@ -127,6 +128,7 @@ class PaymentEntry(AccountsController):
 		party_bank_account: DF.Link | None
 		party_name: DF.Data | None
 		party_type: DF.Link | None
+		payment_date: DF.Datetime | None
 		payment_order: DF.Link | None
 		payment_order_status: DF.Literal["Pending", "Success", "Cancel"]
 		payment_type: DF.Literal["Receive", "Pay", "Internal Transfer"]
@@ -3861,6 +3863,7 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 		)
 		AND company = %(company)s
 		AND customer = %(customer)s
+		AND cancelled_status = "Uncancelled"
 		ORDER BY
 			CASE
 				WHEN name LIKE %(txt)s THEN 0

--- a/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
+++ b/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
@@ -8,7 +8,10 @@
   "bank_transaction",
   "date",
   "allocated_amount",
-  "sepay_transaction_content"
+  "sepay_transaction_content",
+  "sepay_order_number",
+  "sepay_order_description",
+  "sepay_reference_number"
  ],
  "fields": [
   {
@@ -34,6 +37,24 @@
    "fieldname": "sepay_transaction_content",
    "fieldtype": "Small Text",
    "label": "Transaction Content",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sepay_order_number",
+   "fieldtype": "Data",
+   "label": "Order Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sepay_order_description",
+   "fieldtype": "Data",
+   "label": "Order Description",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sepay_reference_number",
+   "fieldtype": "Data",
+   "label": "Reference Number",
    "read_only": 1
   }
 

--- a/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
+++ b/erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json
@@ -11,7 +11,9 @@
   "sepay_transaction_content",
   "sepay_order_number",
   "sepay_order_description",
-  "sepay_reference_number"
+  "sepay_reference_number",
+  "sepay_id",
+  "auto_updated"
  ],
  "fields": [
   {
@@ -56,6 +58,20 @@
    "fieldtype": "Data",
    "label": "Reference Number",
    "read_only": 1
+  },
+  {
+   "fieldname": "sepay_id",
+   "fieldtype": "Data",
+   "label": "Sepay ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "auto_updated",
+   "fieldtype": "Check",
+   "label": "Auto Updated",
+   "read_only": 1,
+   "hidden": 1,
+   "default": "0"
   }
 
  ],

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -91,6 +91,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Total Amount",
+   "precision": "0",
    "print_hide": 1,
    "read_only": 1
   },
@@ -108,6 +109,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Balance",
+   "precision": "0",
    "read_only": 1
   },
   {
@@ -115,7 +117,8 @@
    "fieldname": "allocated_amount",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Allocated"
+   "label": "Allocated",
+   "precision": "0"
   },
   {
    "depends_on": "eval:(doc.reference_doctype=='Purchase Invoice')",

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -49,7 +49,7 @@
    "search_index": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fetch_from": "reference_name.order_number",
    "fieldname": "order_number",
@@ -59,7 +59,7 @@
    "read_only": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fetch_from": "reference_name.split_order_group_name",
    "fieldname": "split_order_group_name",
@@ -103,17 +103,17 @@
    "read_only": 1
   },
   {
-   "columns": 1,
+   "columns": 2,
    "depends_on": "eval:doc.reference_doctype=='Sales Order'",
    "fieldname": "balance",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Balance",
-   "precision": "0",
-   "read_only": 1
+   "read_only": 1,
+   "precision": "0"
   },
   {
-   "columns": 1,
+   "columns": 2,
    "fieldname": "allocated_amount",
    "fieldtype": "Float",
    "in_list_view": 1,

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -830,6 +830,7 @@ def make_address(args, is_primary_address=1, is_shipping_address=1):
 		{
 			"doctype": "Address",
 			"address_title": args.get(party_name_key),
+			"address_name": args.get(party_name_key),
 			"address_line1": args.get("address_line1"),
 			"address_line2": args.get("address_line2"),
 			"city": args.get("city"),


### PR DESCRIPTION
### **User description**
#### Changes
- When Bank Transaction's (BT) [payment_entries](cci:1://file:///Users/mac/git/jemmia/erp/apps/erpnext/erpnext/accounts/doctype/bank_transaction/bank_transaction.py:175:1-188:4) is updated, automatically link Payment Entry (PE) to Bank Transaction via Payment Entry's child table [bank_transactions](cci:1://file:///Users/mac/git/jemmia/erp/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py:3814:0-3845:2)
  - For **automatic flow** (fn/API updates): Sends webhook to fn server for verification
  - For **manual flow** (salesperson links): Webhook will be sent with different logic
  
#### After merge
1. Configure the ERP webhook on the `Payment Entry` doctype with the `on_update` hook.
2. Trigger when `doc.bank_transactions` exists and `doc.bank_transactions[0].sepay_id` and `doc.bank_transactions[0].auto_updated` are present.
3. POST to fn_base_url/webhook/frappe/erp/bank-transactions/verify
4. Use the `short` background queue.
5. Enable webhook security.
6. Jinja template:
```jinja
{
  "bank_transaction_name": "{{ doc.bank_transactions[0].bank_transaction }}",
  "payment_entry_name": "{{ doc.name }}",
  "name": "{{ doc.bank_transactions[0].bank_transaction }}",
  "sepay_id": "{{ frappe.db.get_value('Bank Transaction', doc.bank_transactions[0].bank_transaction, 'sepay_id') }}",
  "sepay_order_number": "{{ doc.bank_transactions[0].sepay_order_number }}",
  "sepay_order_description": "{{ doc.bank_transactions[0].sepay_order_description }}",
  "sepay_reference_number": "{{ doc.bank_transactions[0].sepay_reference_number }}",
  "sepay_amount_in": {{ frappe.db.get_value('Bank Transaction', doc.bank_transactions[0].bank_transaction, 'sepay_amount_in') or 0 }},
  "deposit": {{ frappe.db.get_value('Bank Transaction', doc.bank_transactions[0].bank_transaction, 'deposit') or 0 }},
  "payment_entries": [{
    "payment_document": "Payment Entry",
    "payment_entry": "{{ doc.name }}",
    "allocated_amount": {{ doc.bank_transactions[0].allocated_amount or 0 }}
  }],
  "references": [
    {% for ref in doc.references %}
    {
      "reference_doctype": "{{ ref.reference_doctype }}",
      "reference_name": "{{ ref.reference_name }}",
      "total_amount": {{ ref.total_amount or 0 }}
    }{% if not loop.last %},{% endif %}
    {% endfor %}
  ],
  "mode_of_payment": "{{ doc.mode_of_payment or '' }}"
}
```


___

### **PR Type**
Enhancement


___

### **Description**
- Automatically sync Bank Transaction to Payment Entry when payment entries updated

- Add sepay fields to Payment Entry Bank Transaction child table

- Populate sepay data when selecting Bank Transaction in Payment Entry

- Prevent infinite loops with bidirectional sync flags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BT["Bank Transaction<br/>payment_entries updated"]
  PE["Payment Entry<br/>bank_transactions"]
  SYNC1["sync_payment_entry_bank_transactions<br/>BT → PE"]
  SYNC2["sync_bank_transaction_payments<br/>PE → BT"]
  FLAGS["Bidirectional flags<br/>prevent loops"]
  
  BT -- "on_update" --> SYNC1
  PE -- "on_update" --> SYNC2
  SYNC1 -- "uses" --> FLAGS
  SYNC2 -- "uses" --> FLAGS
  SYNC1 -- "appends to" --> PE
  SYNC2 -- "appends to" --> BT
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bank_transaction.py</strong><dd><code>Add automatic Payment Entry sync on update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/bank_transaction/bank_transaction.py

<ul><li>Added <code>on_update()</code> hook to trigger sync when Bank Transaction is <br>updated<br> <li> Implemented <code>sync_payment_entry_bank_transactions()</code> to automatically <br>link Payment Entry records<br> <li> Appends Bank Transaction data including sepay fields to Payment <br>Entry's bank_transactions table<br> <li> Uses flag <code>updating_linked_bank_transaction</code> to prevent infinite sync <br>loops<br> <li> Includes error handling with frappe logging</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/188/files#diff-8fbd89dc0cfc11b3b5e882108b21dc17d50c547f32cc807a162fe4c9e3344111">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.py</strong><dd><code>Add bidirectional sync loop prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.py

<ul><li>Added guard flag <code>updating_from_bank_transaction</code> to prevent <br>bidirectional sync loops<br> <li> Set flag on Bank Transaction before appending payment entries<br> <li> Maintains existing sync logic for Payment Entry to Bank Transaction <br>direction</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/188/files#diff-a7f7fdc2db51fe011675d0f9a7fb593cd56720070ddea9b391b6c3f816fe140e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.js</strong><dd><code>Fetch and populate sepay fields on selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.js

<ul><li>Extended <code>frappe.db.get_value()</code> call to fetch additional sepay fields <br>from Bank Transaction<br> <li> Added fields: <code>sepay_order_number</code>, <code>sepay_order_description</code>, <br><code>sepay_reference_number</code>, <code>sepay_id</code><br> <li> Populate these fields in Payment Entry Bank Transaction child table on <br>selection</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/188/files#diff-945a4747de34888d5385f1d4f57527e391be523af96a104c2a49792206c89726">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry_bank_transaction.json</strong><dd><code>Add sepay fields and auto_updated flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry_bank_transaction/payment_entry_bank_transaction.json

<ul><li>Added four new read-only sepay fields: <code>sepay_order_number</code>, <br><code>sepay_order_description</code>, <code>sepay_reference_number</code>, <code>sepay_id</code><br> <li> Added <code>auto_updated</code> checkbox field (read-only, hidden) to track <br>automatic updates<br> <li> Updated field_order to include new fields</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/188/files#diff-83d10b38522615c8ed2e0fff4d698bfb2785673f523e797f2f6541b56d1884f1">+38/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

