### PR TITLE
feat(sales-order): Add payment completion date

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -38,6 +38,7 @@
   "column_break_dqxa",
   "cancelled_status",
   "financial_status",
+  "payment_completion_date",
   "fulfillment_status",
   "carrier_status",
   "expected_delivery_date",
@@ -2136,13 +2137,20 @@
    "fieldname": "payment_entries_tab",
    "fieldtype": "Tab Break",
    "label": "Payment Entries"
+  },
+  {
+   "fieldname": "payment_completion_date",
+   "fieldtype": "Datetime",
+   "in_standard_filter": 1,
+   "label": "Payment Completion Date",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-14 08:15:33.295281",
+ "modified": "2025-12-11 08:38:21.260402",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -40,6 +40,7 @@
   "financial_status",
   "payment_completion_date",
   "fulfillment_status",
+  "fulfillment_completion_date",
   "carrier_status",
   "expected_delivery_date",
   "accounting_dimensions_section",
@@ -2144,13 +2145,20 @@
    "in_standard_filter": 1,
    "label": "Payment Completion Date",
    "read_only": 1
+  },
+  {
+   "fieldname": "fulfillment_completion_date",
+   "fieldtype": "Datetime",
+   "in_standard_filter": 1,
+   "label": "Fulfillment Completion Date",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-11 08:38:21.260402",
+ "modified": "2025-12-11 09:37:43.126461",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -114,6 +114,7 @@ class SalesOrder(SellingController):
 		customer_address: DF.Link | None
 		customer_group: DF.Link | None
 		customer_name: DF.Data | None
+		customer_passport_id: DF.Data | None
 		customer_personal_id: DF.Data | None
 		customer_type: DF.Literal["", "New Customer", "Returning Customer"]
 		date_of_issuance: DF.Date | None
@@ -133,6 +134,7 @@ class SalesOrder(SellingController):
 		expected_payment_date: DF.Date | None
 		financial_status: DF.Literal["", "Paid", "Partially Paid", "Partially Refunded", "Refunded", "Pending"]
 		from_date: DF.Date | None
+		fulfillment_completion_date: DF.Datetime | None
 		fulfillment_status: DF.Literal["", "Fulfilled", "Not Fulfilled"]
 		gender: DF.Data | None
 		grand_total: DF.Currency

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -114,7 +114,6 @@ class SalesOrder(SellingController):
 		customer_address: DF.Link | None
 		customer_group: DF.Link | None
 		customer_name: DF.Data | None
-		customer_passport_id: DF.Data | None
 		customer_personal_id: DF.Data | None
 		customer_type: DF.Literal["", "New Customer", "Returning Customer"]
 		date_of_issuance: DF.Date | None

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -114,6 +114,7 @@ class SalesOrder(SellingController):
 		customer_address: DF.Link | None
 		customer_group: DF.Link | None
 		customer_name: DF.Data | None
+		customer_passport_id: DF.Data | None
 		customer_personal_id: DF.Data | None
 		customer_type: DF.Literal["", "New Customer", "Returning Customer"]
 		date_of_issuance: DF.Date | None
@@ -161,6 +162,7 @@ class SalesOrder(SellingController):
 		packed_items: DF.Table[PackedItem]
 		paid_amount: DF.Currency
 		party_account_currency: DF.Link | None
+		payment_completion_date: DF.Datetime | None
 		payment_entries: DF.Table[PaymentEntryReference]
 		payment_records: DF.Table[SalesOrderPaymentRecord]
 		payment_schedule: DF.Table[PaymentSchedule]


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add `payment_completion_date` field to Sales Order doctype

- Add `customer_passport_id` field to Sales Order doctype

- Configure `payment_completion_date` as read-only datetime field

- Enable `payment_completion_date` in standard filters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SO["Sales Order"] -->|adds fields| PCD["payment_completion_date<br/>Datetime Read-only"]
  SO -->|adds fields| CPI["customer_passport_id<br/>Data Field"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Add field definitions to Sales Order class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<ul><li>Add <code>customer_passport_id</code> field definition to class attributes<br> <li> Add <code>payment_completion_date</code> field definition to class attributes</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/194/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales_order.json</strong><dd><code>Add payment completion date field configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.json

<ul><li>Add <code>payment_completion_date</code> to field layout after <code>financial_status</code><br> <li> Define <code>payment_completion_date</code> as read-only Datetime field with <br>standard filter enabled<br> <li> Update modified timestamp to reflect schema changes</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/194/files#diff-60468f41a3b442dc6134bd9661f3225db58882f960aac83ef55325cf7f7b980e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

