### PR TITLE
enhance(payment entry): adding cancel button and updating auto cancelation logic

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -386,6 +386,47 @@ frappe.ui.form.on("Payment Entry", {
 		erpnext.accounts.unreconcile_payment.add_unreconcile_btn(frm);
 		frappe.flags.allocate_payment_amount = true;
 
+		if (frm.doc.docstatus === 0 && !frm.is_new()) {
+			frm.events.get_payment_code(frm, (payment_code) => {
+				let can_cancel = true;
+				if (payment_code === "banking") {
+					if (frm.doc.bank_transactions && frm.doc.bank_transactions.length > 0) {
+						can_cancel = false;
+					}
+				}
+
+				if (["cash_on_delivery", "cash", "pos", "payment_link"].includes(payment_code)) {
+					if (frm.doc.verified_by) {
+						can_cancel = false;
+					}
+				}
+
+				if (can_cancel) {
+					frm.add_custom_button(__("Cancel"), function () {
+						frappe.confirm(
+							__("Bạn có chắc chắn muốn huỷ Phiếu thanh toán này không?"),
+							function () {
+								frappe.call({
+									method: "cancel_draft_payment_entry",
+									doc: frm.doc,
+									callback: function (r) {
+										if (!r.exc) {
+											frappe.show_alert({
+												message: __("Huỷ Phiếu thanh toán thành công"),
+												indicator: "green"
+											});
+											frm.reload_doc();
+										}
+									}
+								});
+							}
+						);
+					}).addClass("btn-danger");
+				}
+			});
+		}
+
+
 		if (frm.doc.qr_url) {
 			const qr_group = __("Mã QR");
 			frm.add_custom_button(__("Copy URL"), () => {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4046,23 +4046,46 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 def cancel_pending_transfers():
 	from frappe.utils import add_to_date, now_datetime
 
-	# Calculate threshold time (24 hours ago)
 	threshold_time = add_to_date(now_datetime(), hours=-24)
-
 	allowed_modes = frappe.get_all("Mode of Payment", filters={"payment_code": "banking"}, pluck="name")
 
 	if not allowed_modes:
 		return
 
-	payment_entries = frappe.get_all(
+	all_pending_entries = frappe.get_all(
 		"Payment Entry",
 		filters={
 			"custom_transfer_status": "pending",
 			"creation": ("<", threshold_time),
 			"mode_of_payment": ["in", allowed_modes]
 		},
-		fields=["name"]
+		pluck="name"
 	)
 
-	for entry in payment_entries:
-		frappe.db.set_value("Payment Entry", entry.name, "custom_transfer_status", "cancel")
+	if not all_pending_entries:
+		return
+
+	entries_with_bank_transactions = frappe.get_all(
+		"Payment Entry Bank Transaction",
+		filters={
+			"parent": ["in", all_pending_entries]
+		},
+		pluck="parent"
+	)
+
+	payment_entry_names = list(set(all_pending_entries) - set(entries_with_bank_transactions))
+
+	if not payment_entry_names:
+		return
+
+	frappe.db.sql("""
+		UPDATE `tabPayment Entry`
+		SET custom_transfer_status = 'cancel',
+			docstatus = 2,
+			status = 'Cancelled',
+			payment_order_status = 'Cancel'
+		WHERE name IN ({})
+	""".format(','.join(['%s'] * len(payment_entry_names))), 
+	payment_entry_names)
+
+	frappe.db.commit()

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -479,6 +479,34 @@ class PaymentEntry(AccountsController):
 
 		update_payment_requests_as_per_pe_references(self.references, cancel=cancel)
 
+	@frappe.whitelist()
+	def cancel_draft_payment_entry(self):
+		if self.docstatus != 0:
+			frappe.throw(_("Chỉ được huỷ Phiếu thanh toán khi đang ở trạng thái Nháp"))
+
+		payment_code = None
+		if self.mode_of_payment:
+			payment_code = frappe.db.get_value("Mode of Payment", self.mode_of_payment, "payment_code")
+
+		if payment_code == "banking":
+			if self.bank_transactions and len(self.bank_transactions) > 0:
+				frappe.throw(_("Không thể huỷ Phiếu thanh toán chuyển khoản đã có giao dịch ngân hàng"))
+
+		if payment_code in ["cash_on_delivery", "cash", "pos", "payment_link"]:
+			if self.verified_by:
+				frappe.throw(_("Không thể huỷ Phiếu thanh toán đã được xác nhận"))
+
+		frappe.db.sql("""
+			UPDATE `tabPayment Entry`
+			SET docstatus = 2,
+			status = 'Cancelled',
+			payment_order_status = "Cancel"
+			WHERE name = %s
+		""", self.name)
+
+		frappe.db.commit()
+		return {"message": _("Huỷ Phiếu thanh toán thành công")}
+
 	def update_outstanding_amounts(self):
 		self.set_missing_ref_details(force=True)
 


### PR DESCRIPTION
##### Changes
- Added a **Cancel** button. A Payment Entry can be cancelled only when:
  - It is a **Banking** payment and has **no Bank Transaction** linked, or
  - It is another payment type and has **not been verified by Accounting**
- Refactored and optimized the auto-cancel logic for Payment Entries
  - Banking Payment Entries are now cancelled **only if no Bank Transaction is linked**
