### PR TITLE
Enhance/payment entry/shown grand total when searching for sales order

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -3,7 +3,7 @@
  "allow_auto_repeat": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
- "creation": "2025-12-07 19:16:48.513741",
+ "creation": "2025-12-24 17:17:11.411328",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -26,6 +26,7 @@
   "company",
   "payment_order_status",
   "party",
+  "shipping_code",
   "qr_section_break",
   "custom_transaction_id",
   "custom_transfer_status",
@@ -976,6 +977,12 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Webhook Process"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal && doc.payment_code == 'cash_on_delivery'",
+   "fieldname": "shipping_code",
+   "fieldtype": "Data",
+   "label": "Shipping Code"
   }
  ],
  "grid_page_length": 50,
@@ -990,7 +997,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-12 09:42:11.806026",
+ "modified": "2025-12-24 17:26:22.946488",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -213,7 +213,7 @@
    "label": "Payment Status",
    "no_copy": 1,
    "options": "Pending\nSuccess\nCancel",
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "gateway",
@@ -237,7 +237,7 @@
    "fieldtype": "Select",
    "label": "Transfer Status",
    "options": "\npending\nsuccess\ncancel",
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "qr_url",
@@ -933,25 +933,25 @@
    "label": "Misa Synced",
    "options": "Project",
    "print_hide": 1,
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "misa_sync_guid",
    "fieldtype": "Data",
    "label": "Misa GUID",
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "misa_synced_at",
    "fieldtype": "Datetime",
    "label": "Misa Synced At",
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "misa_sync_error_msg",
    "fieldtype": "Data",
    "label": "Misa Failed Message",
-   "read_only": 1
+   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
   },
   {
    "fieldname": "dimension_col_break_2",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -3,7 +3,7 @@
  "allow_auto_repeat": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
- "creation": "2025-12-24 17:17:11.411328",
+ "creation": "2025-12-24 17:28:19.328781",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -214,7 +214,7 @@
    "label": "Payment Status",
    "no_copy": 1,
    "options": "Pending\nSuccess\nCancel",
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1
   },
   {
    "fieldname": "gateway",
@@ -238,7 +238,7 @@
    "fieldtype": "Select",
    "label": "Transfer Status",
    "options": "\npending\nsuccess\ncancel",
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1
   },
   {
    "fieldname": "qr_url",
@@ -933,26 +933,26 @@
    "in_standard_filter": 1,
    "label": "Misa Synced",
    "options": "Project",
-   "print_hide": 1,
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1,
+   "print_hide": 1
   },
   {
    "fieldname": "misa_sync_guid",
    "fieldtype": "Data",
    "label": "Misa GUID",
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1
   },
   {
    "fieldname": "misa_synced_at",
    "fieldtype": "Datetime",
    "label": "Misa Synced At",
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1
   },
   {
    "fieldname": "misa_sync_error_msg",
    "fieldtype": "Data",
    "label": "Misa Failed Message",
-   "read_only_depends_on": "eval: !(frappe.user.has_role('Developer') || frappe.user.has_role('Administrator'))"
+   "permlevel": 1
   },
   {
    "fieldname": "dimension_col_break_2",
@@ -997,7 +997,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-24 17:26:22.946488",
+ "modified": "2025-12-25 09:40:30.108619",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4067,7 +4067,7 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 	"""Custom query to search Sales Orders by name and order_number"""
 	return frappe.db.sql(
 		"""
-		SELECT name, order_number, customer_name
+		SELECT name, FORMAT(grand_total, 0) as grand_total, order_number, customer_name
 		FROM `tabSales Order`
 		WHERE (
 			name LIKE %(txt)s
@@ -4077,6 +4077,7 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 		AND company = %(company)s
 		AND customer = %(customer)s
 		AND cancelled_status = "Uncancelled"
+		AND grand_total > 0
 		ORDER BY
 			CASE
 				WHEN name LIKE %(txt)s THEN 0

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -147,6 +147,7 @@ class PaymentEntry(AccountsController):
 		references: DF.Table[PaymentEntryReference]
 		remarks: DF.SmallText | None
 		sales_taxes_and_charges_template: DF.Link | None
+		shipping_code: DF.Data | None
 		source_exchange_rate: DF.Float
 		status: DF.Literal["", "Draft", "Submitted", "Cancelled"]
 		target_exchange_rate: DF.Float


### PR DESCRIPTION
#### Changes
- Update the sales order references search, that exclude 0 vnđ order and display grand_total
<img width="580" height="506" alt="image" src="https://github.com/user-attachments/assets/bfdc221a-7cde-4cbe-ae7b-42b1225ec74a" />

- Allow Administrator, Developer to edit several field
- Adding `shipping_code` for cash_on_delivery PE and only display after create document