### PR TITLE
feat(payment-entry): added notification sent check field

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -27,6 +27,7 @@
   "payment_order_status",
   "party",
   "shipping_code",
+  "notification_sent",
   "qr_section_break",
   "custom_transaction_id",
   "custom_transfer_status",
@@ -983,6 +984,14 @@
    "fieldname": "shipping_code",
    "fieldtype": "Data",
    "label": "Shipping Code"
+  },
+  {
+   "default": "0",
+   "fieldname": "notification_sent",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Notification Sent",
+   "print_hide": 1
   }
  ],
  "grid_page_length": 50,
@@ -997,7 +1006,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-25 09:40:30.108619",
+ "modified": "2025-12-25 11:34:19.343649",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -114,6 +114,7 @@ class PaymentEntry(AccountsController):
 		mode_of_payment: DF.Link
 		name_display: DF.Data | None
 		naming_series: DF.Literal["ACC-PAY-.YYYY.-"]
+		notification_sent: DF.Check
 		paid_amount: DF.Currency
 		paid_amount_after_tax: DF.Currency
 		paid_from: DF.Link | None


### PR DESCRIPTION
#### Changes
- Added hidden `notification_sent` field
  - this field only update via our [Notification doctype](https://erp.jemmia.vn/app/notification/alert_sales_when_customer_paid) after sent first email/notification
  - This field help prevent notification send multiple time

Task: [Link](https://applink.larksuite.com/client/todo/detail?guid=199fd1cf-ee3f-426b-bcbe-2c8dd43e4ad8&suite_entity_num=t117209)