### PR TITLE
enhance (payment entry): added customer phone and order filter logic

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4185,7 +4185,7 @@ def get_payment_entry_list(doctype=None, txt="", searchfield="name", start=0, pa
 		values["phone"] = f"%{phone_search}%"
 
 	if order_number_search:
-		conditions.append("per.order_number LIKE %(order_number)s")
+		conditions.append("(per.order_number LIKE %(order_number)s OR per.split_order_group_name LIKE %(order_number)s)")
 		values["order_number"] = f"%{order_number_search}%"
 
 	if reference_filter == "has_references":

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4150,3 +4150,147 @@ def cancel_pending_transfers():
 			frappe.log_error(f"Failed to cancel Payment Entry {name}: {str(e)}")
 
 	frappe.db.commit()
+
+
+@frappe.whitelist()
+def get_payment_entries_by_phone(phone):
+	if not phone:
+		return []
+	
+	phone = phone.strip()
+	
+	customers = frappe.db.sql("""
+		SELECT name
+		FROM `tabCustomer`
+		WHERE mobile_no LIKE %(phone)s
+		OR phone LIKE %(phone)s
+	""", {"phone": f"%{phone}%"}, as_list=True)
+	
+	if not customers:
+		return []
+	
+	customer_names = [c[0] for c in customers]
+	
+	payment_entries = frappe.db.sql("""
+		SELECT name
+		FROM `tabPayment Entry`
+		WHERE party_type = 'Customer'
+		AND party IN %(customers)s
+		ORDER BY creation DESC
+	""", {"customers": customer_names}, as_list=True)
+	
+	return [pe[0] for pe in payment_entries] if payment_entries else []
+
+
+@frappe.whitelist()
+def get_payment_entries_by_order_number(order_number):
+	if not order_number:
+		return []
+	
+	order_number = order_number.strip()
+	
+	payment_entries = frappe.db.sql("""
+		SELECT DISTINCT parent
+		FROM `tabPayment Entry Reference`
+		WHERE order_number LIKE %(order_number)s
+		ORDER BY creation DESC
+	""", {"order_number": f"%{order_number}%"}, as_list=True)
+	
+	return [pe[0] for pe in payment_entries] if payment_entries else []
+
+
+@frappe.whitelist()
+def get_payment_entry_list(doctype=None, txt="", searchfield="name", start=0, page_len=20, filters=None, as_dict=False, **kwargs):
+
+	phone_search = frappe.form_dict.get("phone_search") or kwargs.get("phone_search")
+	order_number_search = frappe.form_dict.get("order_number_search") or kwargs.get("order_number_search")
+	reference_filter = frappe.form_dict.get("reference_filter") or kwargs.get("reference_filter")
+
+	page_len = frappe.form_dict.get("page_length") or kwargs.get("page_length") or page_len or 20
+	start = frappe.form_dict.get("start") or kwargs.get("start") or start or 0
+
+	if not phone_search and not order_number_search and not reference_filter:
+		return None
+
+	conditions = []
+	values = {}
+
+	query = """
+		SELECT DISTINCT pe.*
+		FROM `tabPayment Entry` pe
+	"""
+
+	if order_number_search:
+		query += " INNER JOIN `tabPayment Entry Reference` per ON per.parent = pe.name"
+
+	if phone_search:
+		query += " INNER JOIN `tabCustomer` c ON c.name = pe.party AND pe.party_type = 'Customer'"
+
+	query += " WHERE 1=1"
+
+	if phone_search:
+		conditions.append("(c.mobile_no LIKE %(phone)s OR c.phone LIKE %(phone)s)")
+		values["phone"] = f"%{phone_search}%"
+
+	if order_number_search:
+		conditions.append("per.order_number LIKE %(order_number)s")
+		values["order_number"] = f"%{order_number_search}%"
+
+	if reference_filter == "has_references":
+		conditions.append("EXISTS (SELECT 1 FROM `tabPayment Entry Reference` WHERE parent = pe.name)")
+	elif reference_filter == "no_references":
+		conditions.append("NOT EXISTS (SELECT 1 FROM `tabPayment Entry Reference` WHERE parent = pe.name)")
+
+	if filters:
+		import json
+		if isinstance(filters, str):
+			try:
+				filters = json.loads(filters)
+			except:
+				filters = []
+
+		if isinstance(filters, list):
+			for filter_item in filters:
+				if len(filter_item) >= 4:
+					field = filter_item[1]
+					operator = filter_item[2]
+					value = filter_item[3]
+
+					if field not in ["phone_search", "order_number_search", "reference_filter"]:
+						if operator == "=":
+							conditions.append(f"pe.{field} = %(filter_{field})s")
+							values[f"filter_{field}"] = value
+						elif operator == "!=":
+							conditions.append(f"pe.{field} != %(filter_{field})s")
+							values[f"filter_{field}"] = value
+						elif operator == "like" or operator == "LIKE":
+							conditions.append(f"pe.{field} LIKE %(filter_{field})s")
+							values[f"filter_{field}"] = f"%{value}%"
+						elif operator == "in":
+							conditions.append(f"pe.{field} IN %(filter_{field})s")
+							values[f"filter_{field}"] = value if isinstance(value, (list, tuple)) else [value]
+						elif operator == ">":
+							conditions.append(f"pe.{field} > %(filter_{field})s")
+							values[f"filter_{field}"] = value
+						elif operator == "<":
+							conditions.append(f"pe.{field} < %(filter_{field})s")
+							values[f"filter_{field}"] = value
+						elif operator == ">=":
+							conditions.append(f"pe.{field} >= %(filter_{field})s")
+							values[f"filter_{field}"] = value
+						elif operator == "<=":
+							conditions.append(f"pe.{field} <= %(filter_{field})s")
+							values[f"filter_{field}"] = value
+
+	if txt:
+		conditions.append("(pe.name LIKE %(txt)s OR pe.party_name LIKE %(txt)s)")
+		values["txt"] = f"%{txt}%"
+
+	if conditions:
+		query += " AND " + " AND ".join(conditions)
+
+	query += " ORDER BY pe.modified DESC LIMIT %(start)s, %(page_len)s"
+	values["start"] = int(start)
+	values["page_len"] = int(page_len) if page_len else 100
+
+	return frappe.db.sql(query, values, as_dict=True)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4151,54 +4151,6 @@ def cancel_pending_transfers():
 
 	frappe.db.commit()
 
-
-@frappe.whitelist()
-def get_payment_entries_by_phone(phone):
-	if not phone:
-		return []
-	
-	phone = phone.strip()
-	
-	customers = frappe.db.sql("""
-		SELECT name
-		FROM `tabCustomer`
-		WHERE mobile_no LIKE %(phone)s
-		OR phone LIKE %(phone)s
-	""", {"phone": f"%{phone}%"}, as_list=True)
-	
-	if not customers:
-		return []
-	
-	customer_names = [c[0] for c in customers]
-	
-	payment_entries = frappe.db.sql("""
-		SELECT name
-		FROM `tabPayment Entry`
-		WHERE party_type = 'Customer'
-		AND party IN %(customers)s
-		ORDER BY creation DESC
-	""", {"customers": customer_names}, as_list=True)
-	
-	return [pe[0] for pe in payment_entries] if payment_entries else []
-
-
-@frappe.whitelist()
-def get_payment_entries_by_order_number(order_number):
-	if not order_number:
-		return []
-	
-	order_number = order_number.strip()
-	
-	payment_entries = frappe.db.sql("""
-		SELECT DISTINCT parent
-		FROM `tabPayment Entry Reference`
-		WHERE order_number LIKE %(order_number)s
-		ORDER BY creation DESC
-	""", {"order_number": f"%{order_number}%"}, as_list=True)
-	
-	return [pe[0] for pe in payment_entries] if payment_entries else []
-
-
 @frappe.whitelist()
 def get_payment_entry_list(doctype=None, txt="", searchfield="name", start=0, page_len=20, filters=None, as_dict=False, **kwargs):
 
@@ -4242,7 +4194,6 @@ def get_payment_entry_list(doctype=None, txt="", searchfield="name", start=0, pa
 		conditions.append("NOT EXISTS (SELECT 1 FROM `tabPayment Entry Reference` WHERE parent = pe.name)")
 
 	if filters:
-		import json
 		if isinstance(filters, str):
 			try:
 				filters = json.loads(filters)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
@@ -9,5 +9,98 @@ frappe.listview_settings["Payment Entry"] = {
 				};
 			};
 		}
+
+		let phone_timeout;
+		let order_timeout;
+		let custom_phone_search = null;
+		let custom_order_search = null;
+		let custom_reference_filter = "";
+
+		const original_get_args = listview.get_args.bind(listview);
+		listview.get_args = function() {
+			const args = original_get_args();
+
+			if (custom_phone_search) {
+				args.phone_search = custom_phone_search;
+			}
+			if (custom_order_search) {
+				args.order_number_search = custom_order_search;
+			}
+			if (custom_reference_filter) {
+				args.reference_filter = custom_reference_filter;
+			}
+
+			return args;
+		};
+
+		const original_get_call_args = listview.get_call_args.bind(listview);
+		listview.get_call_args = function(args) {
+			const call_args = original_get_call_args(args);
+			if (custom_phone_search || custom_order_search || custom_reference_filter) {
+				call_args.method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry_list";
+				call_args.phone_search = custom_phone_search;
+				call_args.order_number_search = custom_order_search;
+				call_args.reference_filter = custom_reference_filter;
+			}
+			return call_args;
+		};
+
+		const $filter_area = listview.page.page_form.find('.standard-filter-section');
+		if ($filter_area.length) {
+			const $phone_wrapper = $('<div class="form-group frappe-control input-max-width col-md-2"></div>');
+			const $phone_input = $('<input type="text" autocomplete="off" class="input-with-feedback form-control input-xs" placeholder="' + __('Phone') + '">');
+			$phone_input.on('input', function() {
+				const phone = $(this).val();
+				clearTimeout(phone_timeout);
+				phone_timeout = setTimeout(() => {
+					custom_phone_search = phone || null;
+					listview.refresh();
+				}, 500);
+			});
+			$phone_wrapper.append($phone_input);
+
+			const $order_wrapper = $('<div class="form-group frappe-control input-max-width col-md-2"></div>');
+			const $order_input = $('<input type="text" autocomplete="off" class="input-with-feedback form-control input-xs" placeholder="' + __('Order Number') + '">');
+			$order_input.on('input', function() {
+				const order_number = $(this).val();
+				clearTimeout(order_timeout);
+				
+				order_timeout = setTimeout(() => {
+					custom_order_search = order_number || null;
+					listview.refresh();
+				}, 500);
+			});
+
+			$order_wrapper.append($order_input);
+
+			const $reference_wrapper = $('<div class="form-group frappe-control input-max-width col-md-2"></div>');
+			const $reference_select = $('<select class="input-with-feedback form-control input-xs">' +
+				'<option value="" selected disabled hidden>' + __('Order link status') + '</option>' +
+				'<option value="">' + __('All') + '</option>' +
+				'<option value="has_references">' + __('Order linked') + '</option>' +
+				'<option value="no_references">' + __('Not linked') + '</option>' +
+				'</select>');
+			$reference_select.on('change', function() {
+				custom_reference_filter = $(this).val();
+				listview.refresh();
+			});
+			$reference_wrapper.append($reference_select);
+
+			const $my_entries_wrapper = $('<div class="form-group frappe-control input-max-width col-md-2"></div>');
+			const $my_entries_checkbox = $('<label class="checkbox" style="margin-top: 8px;">' +
+				'<input type="checkbox" class="input-with-feedback"> ' +
+				'<span class="label-area">' + __('My Payment Entries') + '</span>' +
+				'</label>');
+			$my_entries_checkbox.find('input[type="checkbox"]').on('change', function() {
+				if ($(this).is(':checked')) {
+					listview.filter_area.add([["Payment Entry", "created_by_display", "=", frappe.session.user]]);
+				} else {
+					listview.filter_area.remove("created_by_display");
+				}
+			});
+			$my_entries_wrapper.append($my_entries_checkbox);
+
+			$filter_area.append($my_entries_wrapper).append($phone_wrapper).append($order_wrapper).append($reference_wrapper);
+		}
 	},
 };

--- a/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
@@ -1,4 +1,5 @@
 frappe.listview_settings["Payment Entry"] = {
+	hide_name_column: true,
 	onload: function (listview) {
 		if (listview.page.fields_dict.party_type) {
 			listview.page.fields_dict.party_type.get_query = function () {

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -58,7 +58,8 @@
    "fieldname": "order_number",
    "fieldtype": "Data",
    "label": "Order Number",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "mode_of_payment",


### PR DESCRIPTION
##### Glossary
- PE: Payment Entry

#### Changes
- Added an index on the `order_number` field in Payment Entry Reference.
- Added 4 custom filters:
  - **Customer Phone** – Allows users to search Payment Entries by customer phone number.
  - **Order Number** – Leverages the database index to help accountants quickly find Payment Entries by order number.
  - **My Payment Entries** – A checkbox to quickly show Payment Entries created by the current user.
  - **Order Link Status** – A select filter that allows users to quickly find Payment Entries with mapped or unmapped Sales Orders.

#### Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=e3a4d4d7-cd8c-4f50-bd0a-4e75edb3fdb3&suite_entity_num=t117383)

#### Usage

https://github.com/user-attachments/assets/95d81ad5-b1a7-448a-b7eb-10e9c0823f0c


