### PR TITLE
Feature/bank transaction/create few more field for other type of bank transaction

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -2,7 +2,7 @@
  "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
- "creation": "2018-10-22 18:19:02.784533",
+ "creation": "2025-12-08 17:47:45.582788",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -90,7 +90,8 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Bank Account",
-   "options": "Bank Account"
+   "options": "Bank Account",
+   "search_index": 1
   },
   {
    "fetch_from": "bank_account.company",
@@ -335,7 +336,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-11-18 18:32:47.203694",
+ "modified": "2025-12-29 13:27:37.564606",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -54,7 +54,20 @@
   "sepay_reference_number",
   "sepay_code",
   "sepay_sub_account",
-  "sepay_bank_account_id"
+  "sepay_bank_account_id",
+  "payment_link_section",
+  "app_id",
+  "app_time",
+  "app_user",
+  "column_break_zalopay",
+  "zp_trans_id",
+  "embed_data",
+  "item",
+  "column_break_zalopay2",
+  "server_time",
+  "channel",
+  "merchant_user_id",
+  "user_fee_amount"
  ],
  "fields": [
   {
@@ -221,10 +234,12 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "SePay",
    "fieldname": "transaction_type",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
    "label": "Transaction Type",
-   "length": 50
+   "options": "SePay\nZaloPay\nPayoo"
   },
   {
    "fieldname": "column_break_3czf",
@@ -332,11 +347,75 @@
   {
    "fieldname": "column_break_oufv",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "payment_link_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Link Details"
+  },
+  {
+   "fieldname": "app_id",
+   "fieldtype": "Data",
+   "label": "App ID"
+  },
+  {
+   "fieldname": "app_time",
+   "fieldtype": "Data",
+   "label": "App Time"
+  },
+  {
+   "fieldname": "app_user",
+   "fieldtype": "Data",
+   "label": "App User"
+  },
+  {
+   "fieldname": "column_break_zalopay",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "embed_data",
+   "fieldtype": "JSON",
+   "label": "Embed Data"
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "JSON",
+   "label": "Item"
+  },
+  {
+   "fieldname": "zp_trans_id",
+   "fieldtype": "Data",
+   "label": "ZP Trans ID"
+  },
+  {
+   "fieldname": "column_break_zalopay2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "server_time",
+   "fieldtype": "Data",
+   "label": "Server Time"
+  },
+  {
+   "fieldname": "channel",
+   "fieldtype": "Data",
+   "label": "Channel"
+  },
+  {
+   "fieldname": "merchant_user_id",
+   "fieldtype": "Data",
+   "label": "Merchant User ID"
+  },
+  {
+   "fieldname": "user_fee_amount",
+   "fieldtype": "Currency",
+   "label": "User Fee Amount",
+   "precision": "0"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-29 13:27:37.564606",
+ "modified": "2025-12-29 13:58:05.948890",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",
@@ -385,6 +464,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "date",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -20,15 +20,22 @@ class BankTransaction(Document):
 
 		allocated_amount: DF.Currency
 		amended_from: DF.Link | None
+		app_id: DF.Int
+		app_time: DF.Data | None
+		app_user: DF.Data | None
 		bank_account: DF.Link | None
 		bank_party_account_number: DF.Data | None
 		bank_party_iban: DF.Data | None
 		bank_party_name: DF.Data | None
+		channel: DF.Int
 		company: DF.Link | None
 		currency: DF.Link | None
 		date: DF.Date | None
 		deposit: DF.Currency
 		description: DF.SmallText | None
+		embed_data: DF.JSON | None
+		item: DF.JSON | None
+		merchant_user_id: DF.Data | None
 		naming_series: DF.Literal["ACC-BTN-.YYYY.-"]
 		party: DF.DynamicLink | None
 		party_type: DF.Link | None
@@ -48,11 +55,14 @@ class BankTransaction(Document):
 		sepay_sub_account: DF.Data | None
 		sepay_transaction_content: DF.Data | None
 		sepay_transaction_date: DF.Data | None
+		server_time: DF.Data | None
 		status: DF.Literal["", "Pending", "Settled", "Unreconciled", "Reconciled", "Cancelled"]
 		transaction_id: DF.Data | None
 		transaction_type: DF.Data | None
 		unallocated_amount: DF.Currency
+		user_fee_amount: DF.Currency
 		withdrawal: DF.Currency
+		zp_trans_id: DF.Data | None
 	# end: auto-generated types
 
 	def before_validate(self):

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -15,11 +15,8 @@ class BankTransaction(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from erpnext.accounts.doctype.bank_transaction_payments.bank_transaction_payments import BankTransactionPayments
 		from frappe.types import DF
-
-		from erpnext.accounts.doctype.bank_transaction_payments.bank_transaction_payments import (
-			BankTransactionPayments,
-		)
 
 		allocated_amount: DF.Currency
 		amended_from: DF.Link | None
@@ -37,6 +34,20 @@ class BankTransaction(Document):
 		party_type: DF.Link | None
 		payment_entries: DF.Table[BankTransactionPayments]
 		reference_number: DF.Data | None
+		sepay_account_number: DF.Data | None
+		sepay_accumulated: DF.Currency
+		sepay_amount_in: DF.Currency
+		sepay_amount_out: DF.Currency
+		sepay_bank_account_id: DF.Data | None
+		sepay_bank_brand_name: DF.Data | None
+		sepay_code: DF.Data | None
+		sepay_id: DF.Data | None
+		sepay_order_description: DF.Data | None
+		sepay_order_number: DF.Data | None
+		sepay_reference_number: DF.Data | None
+		sepay_sub_account: DF.Data | None
+		sepay_transaction_content: DF.Data | None
+		sepay_transaction_date: DF.Data | None
 		status: DF.Literal["", "Pending", "Settled", "Unreconciled", "Reconciled", "Cancelled"]
 		transaction_id: DF.Data | None
 		transaction_type: DF.Data | None

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction_list.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction_list.js
@@ -3,6 +3,7 @@
 
 frappe.listview_settings["Bank Transaction"] = {
 	add_fields: ["unallocated_amount"],
+	hide_name_column: true,
 	get_indicator: function (doc) {
 		if (doc.docstatus == 2) {
 			return [__("Cancelled"), "red", "docstatus,=,2"];


### PR DESCRIPTION
#### Changes
- Added an index on `bank_account`.
- Added several preparations for the upcoming `payment_link` migration into ERP.
- Hid the ID column in the list view.

Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=ffcdab38-9f30-4eb0-b2c8-efe7b62b43a1&suite_entity_num=t117371)

#### Note
Several `sepay_*` fields were added in the Python code because they were not committed in a previous commit.
