### PR TITLE
Feat(CRM): Setup Prefix Coupon

### DIFF
--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -322,7 +322,7 @@ frappe.ui.form.on("Customer", {
 					'customer': frm.doc.name,
 					'cancelled_status': 'Uncancelled'
 				},
-				fields: ['name', 'order_number', 'transaction_date', 'status', 'grand_total', 'currency', 'haravan_order_id', 'cancelled_status', 'financial_status'],
+				fields: ['name', 'order_number', 'transaction_date', 'status', 'grand_total', 'currency', 'haravan_order_id', 'cancelled_status', 'financial_status', 'haravan_coupon_code'],
 				order_by: 'transaction_date desc',
 				limit_page_length: 20
 			},
@@ -343,6 +343,7 @@ frappe.ui.form.on("Customer", {
 										<tr style="border-bottom: 1px solid #dee2e6;">
 											<th style="${tabledHeadStyle}">Order Number</th>
 											<th style="${tabledHeadStyle}">Order Date</th>
+											<th style="${tabledHeadStyle}">Coupon</th>
 											<th style="${tabledHeadStyle}">Financial Status</th>
 											<th style="${tabledHeadStyle} text-align: right;">Grand Total</th>
 										</tr>
@@ -363,6 +364,13 @@ frappe.ui.form.on("Customer", {
 						}
 
 						const display_order_number = order.order_number || order.name;
+						
+						let coupon_display = '';
+						if (order.haravan_coupon_code) {
+							// Split by newline and wrap in code/badge
+							const coupons = order.haravan_coupon_code.split('\n').filter(c => c.trim());
+							coupon_display = coupons.map(c => `<span style="background-color: #f0f4f8; padding: 2px 6px; border-radius: 4px; font-family: monospace; color: #333; display: inline-block; margin-right: 4px; margin-bottom: 2px;">${c}</span>`).join('');
+						}
 
 						html += `
 							<tr style="border-bottom: 1px solid #f1f3f4;">
@@ -371,6 +379,9 @@ frappe.ui.form.on("Customer", {
 								</td>
 								<td style="${tableDataStyle} color: #6c757d;">
 									${frappe.datetime.str_to_user(order.transaction_date)}
+								</td>
+								<td style="${tableDataStyle}">
+									${coupon_display}
 								</td>
 								<td style="${tableDataStyle}">
 									${financial_status_badge}

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -54,6 +54,7 @@
   "doc_image",
   "orther_section",
   "first_source",
+  "customer_identity_image",
   "customer_website",
   "column_break_ioxt",
   "customer_journey",
@@ -698,6 +699,12 @@
    "label": "Identity Document"
   },
   {
+   "fieldname": "customer_identity_image",
+   "fieldtype": "Attach Image",
+   "label": "Customer Identity Image",
+   "print_hide": 1
+  },
+  {
    "fieldname": "birth_date",
    "fieldtype": "Date",
    "label": "Birth Date"
@@ -1110,7 +1117,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-11-17 12:24:33.883694",
+ "modified": "2026-01-05 04:26:15.456289",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -72,21 +72,19 @@ class Customer(TransactionBase):
 		bizfly_customer_number: DF.Data | None
 		bizfly_id: DF.Data | None
 		buyback_revenue: DF.Currency
-		cashback: DF.Currency
 		ceo_name: DF.Data | None
 		companies: DF.Table[AllowedToTransactWith]
 		company_name: DF.Data | None
 		coupon_table: DF.Table[Coupon]
 		credit_limits: DF.Table[CustomerCreditLimit]
-		cumulative_revenue: DF.Currency
 		customer_details: DF.Text | None
 		customer_group: DF.Link | None
+		customer_identity_image: DF.AttachImage | None
 		customer_journey: DF.SmallText | None
 		customer_name: DF.Data
 		customer_pos_id: DF.Data | None
 		customer_primary_address: DF.Link | None
 		customer_primary_contact: DF.Link | None
-		customer_rank: DF.Literal["No Rank", "Silver", "Gold", "Platinum"]
 		customer_type: DF.Literal["Company", "Individual", "Partnership"]
 		customer_website: DF.Data | None
 		date_of_issuance: DF.Date | None
@@ -118,11 +116,10 @@ class Customer(TransactionBase):
 		naming_series: DF.Literal["CUST-.YYYY.-"]
 		no_of_employees: DF.Data | None
 		opportunity_name: DF.Link | None
+		partner_role: DF.Data | None
 		passport_expiry_date: DF.Date | None
 		passport_id: DF.Data | None
 		payment_terms: DF.Link | None
-		pending_cashback: DF.Currency
-		pending_point: DF.Float
 		person_name: DF.Data | None
 		personal_document_type: DF.Literal["CCCD", "Passport"]
 		personal_id: DF.Data | None
@@ -136,13 +133,10 @@ class Customer(TransactionBase):
 		priority_bank_account: DF.Link | None
 		priority_login_date: DF.Date | None
 		prospect_name: DF.Link | None
-		purchase_amount_last_12_months: DF.Currency
 		rank: DF.Literal["No Rank", "Silver", "Gold", "Platinum"]
-		rank_expired_date: DF.Date | None
 		rank_score_12m: DF.Currency
 		rank_updated_at: DF.Date | None
 		referral_cumulative_revenue: DF.Currency
-		referrals_revenue: DF.Currency
 		represents_company: DF.Link | None
 		sales_team: DF.Table[SalesTeam]
 		salutation: DF.Link | None
@@ -154,14 +148,12 @@ class Customer(TransactionBase):
 		territory: DF.Link | None
 		total_cumulative_revenue: DF.Currency
 		total_referral_point: DF.Float
-		true_cumulative_revenue: DF.Currency
 		vat_address: DF.Data | None
 		vat_email: DF.Data | None
 		vat_name: DF.Data | None
 		website: DF.Data | None
 		withdraw_cash_amount: DF.Currency
 		withdraw_cash_amount_pending: DF.Currency
-		withdraw_cashback: DF.Currency
 		withdraw_point: DF.Float
 	# end: auto-generated types
 

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -15,6 +15,7 @@
   "title",
   "naming_series",
   "tax_id",
+  "haravan_coupon_code",
   "column_break1",
   "order_type",
   "skip_delivery_note",
@@ -1827,6 +1828,11 @@
    "read_only": 1
   },
   {
+   "fieldname": "haravan_coupon_code",
+   "fieldtype": "Small Text",
+   "label": "Haravan Coupon Codes"
+  },
+  {
    "fieldname": "section_break_uceh",
    "fieldtype": "Section Break"
   },
@@ -2210,7 +2216,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-26 03:13:06.976730",
+ "modified": "2026-01-05 04:19:22.213945",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1830,7 +1830,8 @@
   {
    "fieldname": "haravan_coupon_code",
    "fieldtype": "Small Text",
-   "label": "Haravan Coupon Codes"
+   "label": "Haravan Coupon Codes",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_uceh",
@@ -2216,7 +2217,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-05 04:19:22.213945",
+ "modified": "2026-01-05 04:41:59.264750",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -82,6 +82,8 @@ class SalesOrder(SellingController):
 		apply_discount_on: DF.Literal["", "Grand Total", "Net Total"]
 		auto_repeat: DF.Link | None
 		balance: DF.Currency
+		balance_group_payment: DF.Currency
+		balance_payment: DF.Currency
 		base_discount_amount: DF.Currency
 		base_grand_total: DF.Currency
 		base_in_words: DF.Data | None
@@ -141,6 +143,7 @@ class SalesOrder(SellingController):
 		grand_total: DF.Currency
 		group_payment_entries: DF.Table[PaymentEntryReference]
 		group_same_items: DF.Check
+		haravan_coupon_code: DF.SmallText | None
 		haravan_created_at: DF.Datetime | None
 		haravan_order_id: DF.Data | None
 		haravan_ref_order_id: DF.Data | None
@@ -218,6 +221,8 @@ class SalesOrder(SellingController):
 		title: DF.Data | None
 		to_date: DF.Date | None
 		total: DF.Currency
+		total_allocated_group_payment: DF.Currency
+		total_allocated_payment: DF.Currency
 		total_amount: DF.Currency
 		total_commission: DF.Currency
 		total_net_weight: DF.Float
@@ -476,6 +481,8 @@ class SalesOrder(SellingController):
 			from erpnext.accounts.doctype.pricing_rule.utils import validate_coupon_code
 
 			validate_coupon_code(self.coupon_code)
+
+		self.validate_sensitive_coupons()
 
 		self.set_order_policies_summary()
 
@@ -796,6 +803,40 @@ class SalesOrder(SellingController):
 
 	def on_update(self):
 		pass
+
+	def validate_sensitive_coupons(self):
+		"""
+		US2: Check if haravan coupon codes are partner coupons and require customer identity image.
+		Partner coupons are identified by having a hyphen "-" in the code.
+		Supports multiple coupon codes separated by newline.
+		"""
+		if not self.haravan_coupon_code:
+			return
+		
+		# Parse multiple coupon codes (separated by newline)
+		coupon_codes = []
+		for code in self.haravan_coupon_code.split("\n"):
+			code = code.strip()
+			if code:
+				coupon_codes.append(code)
+		
+		# Check if any coupon code is a partner coupon (contains hyphen)
+		partner_coupons = []
+		for coupon_code in coupon_codes:
+			if "-" in coupon_code:
+				partner_coupons.append(coupon_code)
+		
+		if partner_coupons:
+			# Check if customer has identity image
+			has_image = frappe.db.get_value("Customer", self.customer, "customer_identity_image")
+			if not has_image:
+				frappe.throw(
+					_("Đơn hàng sử dụng mã giới thiệu Partner {0} yêu cầu nhân viên phải upload hình ảnh xác minh vào hồ sơ khách hàng {1} trước khi cho phép lưu đơn hàng.").format(
+						frappe.bold(", ".join(partner_coupons)),
+						frappe.bold(self.customer)
+					),
+					title=_("Thiếu thông tin khách hàng")
+				)
 
 	def set_order_policies_summary(self):
 		summary = []


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add partner coupon validation requiring customer identity image

- Display coupon codes in customer sales order history

- Add haravan coupon code field to sales order

- Refactor customer fields removing unused revenue tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SO["Sales Order"] -- "validate_sensitive_coupons" --> CC["Haravan Coupon Code"]
  CC -- "check for hyphen" --> PC["Partner Coupon"]
  PC -- "requires" --> CII["Customer Identity Image"]
  CUST["Customer Form"] -- "display coupons" --> SOH["Sales Order History"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.py</strong><dd><code>Remove unused fields and add identity image field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.py

<ul><li>Remove unused revenue tracking fields (cashback, cumulative_revenue, <br>pending_cashback, pending_point, purchase_amount_last_12_months, <br>rank_expired_date, referrals_revenue, true_cumulative_revenue, <br>withdraw_cashback)<br> <li> Remove customer_rank field (consolidated to rank field)<br> <li> Add customer_identity_image field for identity verification<br> <li> Add partner_role field for partner tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/233/files#diff-6c864e7eb264f62092ce56e22731b2736152c26b9c8961d5039c8cb8b9361f2e">+2/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Add coupon validation and payment tracking fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<ul><li>Add haravan_coupon_code field to store coupon codes from Haravan<br> <li> Add balance_group_payment and balance_payment fields for payment <br>tracking<br> <li> Add total_allocated_group_payment and total_allocated_payment fields<br> <li> Implement validate_sensitive_coupons method to check partner coupons <br>(containing hyphen) and require customer identity image<br> <li> Call validation in validate method before setting order policies</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/233/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>customer.js</strong><dd><code>Display coupon codes in sales order history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.js

<ul><li>Add haravan_coupon_code to fields fetched in sales order list query<br> <li> Add Coupon column to sales order history table<br> <li> Parse and display multiple coupon codes separated by newlines<br> <li> Style coupon codes as inline badges with monospace font</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/233/files#diff-6da7c16d1d898787d987629cde89ca0076ef65b1e996874013a8ea46935e41ff">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.json</strong><dd><code>Add customer identity image field to schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/customer/customer.json

<ul><li>Add customer_identity_image field to Identity Document section<br> <li> Set field as Attach Image type with print_hide enabled<br> <li> Update modified timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/233/files#diff-e851c9f6c12204fced775db0f626fa7ccb65899189362a9312d8b94bc59d160d">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sales_order.json</strong><dd><code>Add haravan coupon code field to schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.json

<ul><li>Add haravan_coupon_code field to customer section with read-only <br>access<br> <li> Set field type as Small Text for storing multiple coupon codes<br> <li> Update modified timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/233/files#diff-60468f41a3b442dc6134bd9661f3225db58882f960aac83ef55325cf7f7b980e">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

