### PR TITLE
Feature/payment entry/bypass allocated amount if role is dev or admin

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1435,6 +1435,12 @@ frappe.ui.form.on("Payment Entry", {
 			return;
 		}
 
+		if (frappe.user.has_role("Administrator") || frappe.user.has_role("Developer")) {
+			frm.doc.admin_editing = 1;
+			return;
+		}
+
+
 		let total_allocated = 0;
 
 		$.each(frm.doc.references || [], function (i, row) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -123,6 +123,7 @@
   "subscription_section",
   "auto_repeat",
   "amended_from",
+  "admin_editing",
   "title"
  ],
  "fields": [
@@ -992,6 +993,15 @@
    "hidden": 1,
    "label": "Notification Sent",
    "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "admin_editing",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Admin Editing",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -75,6 +75,7 @@ class PaymentEntry(AccountsController):
 		from frappe.types import DF
 
 		amended_from: DF.Link | None
+		admin_editing: DF.Check
 		apply_tax_withholding_amount: DF.Check
 		auto_repeat: DF.Link | None
 		bank: DF.ReadOnly | None


### PR DESCRIPTION
### **User description**
#### Changes
- Bypass Payment entry: references sales order allocated_amount


___

### **PR Type**
Enhancement


___

### **Description**
- Add `admin_editing` field to bypass allocated amount validation

- Allow Administrator and Developer roles to skip payment entry validation

- Set hidden read-only flag when admin/dev users edit payment entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Payment Entry Validation"] --> B{"User is Admin<br/>or Developer?"}
  B -->|Yes| C["Set admin_editing flag"]
  B -->|No| D["Validate allocated amount"]
  C --> E["Skip validation"]
  D --> F["Standard validation flow"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.py</strong><dd><code>Add admin_editing field type annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.py

<ul><li>Added <code>admin_editing</code> field type annotation to PaymentEntry class<br> <li> Field is defined as a Check type in the TYPE_CHECKING block</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/235/files#diff-a7f7fdc2db51fe011675d0f9a7fb593cd56720070ddea9b391b6c3f816fe140e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.js</strong><dd><code>Implement validation bypass for admin and developer roles</code></dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.js

<ul><li>Added role check in <code>validate_total_allocated_amount</code> function<br> <li> Sets <code>admin_editing</code> flag to 1 for Administrator and Developer roles<br> <li> Bypasses allocated amount validation when flag is set</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/235/files#diff-945a4747de34888d5385f1d4f57527e391be523af96a104c2a49792206c89726">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.json</strong><dd><code>Add admin_editing field configuration to form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.json

<ul><li>Added <code>admin_editing</code> field to the form layout<br> <li> Defined field as hidden, read-only Check type with default value 0<br> <li> Field is excluded from print output</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/235/files#diff-1cb8987729b5486a8ec30e408fc0ba91f343f44c8248a10835ce3bea88ce214d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

