### PR TITLE
feature(payment entry): auto display unpaid orders refernces

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -2253,7 +2253,6 @@ frappe.ui.form.on("Payment Entry Reference", {
 
 	allocated_amount: function (frm) {
 		frm.events.set_total_allocated_amount(frm);
-		frm.events.validate_total_allocated_amount(frm);
 	},
 
 	references_remove: function (frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -726,6 +726,15 @@ frappe.ui.form.on("Payment Entry", {
 			});
 		}
 		
+		if (frm.doc.references && frm.doc.references.length > 0) {
+			frm.doc.references.forEach(function(row) {
+				if (row.reference_doctype === "Sales Order") {
+					frappe.model.set_value(row.doctype, row.name, "mode_of_payment", frm.doc.mode_of_payment);
+				}
+			});
+			frm.refresh_field("references");
+		}
+		
 		erpnext.accounts.pos.get_payment_mode_account(frm, frm.doc.mode_of_payment, function (account) {
 			let payment_account_field = frm.doc.payment_type == "Receive" ? "paid_to" : "paid_from";
 			frm.set_value(payment_account_field, account);
@@ -919,7 +928,7 @@ frappe.ui.form.on("Payment Entry", {
 									frappe.model.set_value(row.doctype, row.name, "mode_of_payment", frm.doc.mode_of_payment);
 									frappe.model.set_value(row.doctype, row.name, "gateway", frm.doc.gateway);
 									frappe.model.set_value(row.doctype, row.name, "paid_amount", frm.doc.paid_amount);
-									frappe.model.set_value(row.doctype, row.name, "payment_date", frm.doc.posting_date);
+									frappe.model.set_value(row.doctype, row.name, "payment_date", frm.doc.payment_date);
 									frappe.model.set_value(row.doctype, row.name, "payment_order_status", frm.doc.payment_order_status);
 									
 									frappe.db.get_value("Sales Order", so.name, [
@@ -1115,6 +1124,17 @@ frappe.ui.form.on("Payment Entry", {
 
 	posting_date: function (frm) {
 		frm.events.paid_from_account_currency(frm);
+	},
+
+	payment_date: function (frm) {
+		if (frm.doc.references && frm.doc.references.length > 0) {
+			frm.doc.references.forEach(function(row) {
+				if (row.reference_doctype === "Sales Order") {
+					frappe.model.set_value(row.doctype, row.name, "payment_date", frm.doc.payment_date);
+				}
+			});
+			frm.refresh_field("references");
+		}
 	},
 
 	source_exchange_rate: function (frm) {
@@ -2231,7 +2251,7 @@ frappe.ui.form.on("Payment Entry Reference", {
 							frappe.model.set_value(cdt, cdn, "mode_of_payment", frm.doc.mode_of_payment);
 							frappe.model.set_value(cdt, cdn, "gateway", frm.doc.gateway);
 							frappe.model.set_value(cdt, cdn, "paid_amount", frm.doc.paid_amount);
-							frappe.model.set_value(cdt, cdn, "payment_date", frm.doc.posting_date);
+							frappe.model.set_value(cdt, cdn, "payment_date", frm.doc.payment_date);
 							frappe.model.set_value(cdt, cdn, "payment_order_status", frm.doc.payment_order_status);
 							frappe.db.get_value("Sales Order", row.reference_name, [
 								"order_number",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -862,11 +862,85 @@ frappe.ui.form.on("Payment Entry", {
 									frm.doc.paid_to_account_currency,
 									company_currency
 								),
+							() => frm.events.auto_populate_sales_orders(frm),
 						]);
 					}
 				},
 			});
 		}
+	},
+
+
+	auto_populate_sales_orders: function(frm) {
+		if (!frm.doc.party || !frm.doc.paid_amount) {
+			return;
+		}
+
+		frm.clear_table("references");
+		frappe.call({
+			method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_sales_orders_for_auto_populate",
+			args: {
+				company: frm.doc.company,
+				customer: frm.doc.party
+			},
+			callback: function(r) {
+				if (r.message && r.message.length > 0) {
+					let sales_orders = r.message;
+					let single_order = sales_orders.length === 1;
+
+					sales_orders.forEach(function(so) {
+						let row = frm.add_child("references");
+						row.reference_doctype = "Sales Order";
+						row.reference_name = so.name;
+
+						if (single_order) {
+							row.allocated_amount = frm.doc.paid_amount;
+						} else {
+							row.allocated_amount = 0;
+						}
+
+						frappe.call({
+							method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_reference_details",
+							args: {
+								reference_doctype: "Sales Order",
+								reference_name: so.name,
+								party_account_currency: frm.doc.payment_type == "Receive" 
+									? frm.doc.paid_from_account_currency 
+									: frm.doc.paid_to_account_currency,
+								party_type: frm.doc.party_type,
+								party: frm.doc.party,
+							},
+							callback: function(ref_r) {
+								if (ref_r.message) {
+									$.each(ref_r.message, function(field, value) {
+										frappe.model.set_value(row.doctype, row.name, field, value);
+									});
+
+									frappe.model.set_value(row.doctype, row.name, "mode_of_payment", frm.doc.mode_of_payment);
+									frappe.model.set_value(row.doctype, row.name, "gateway", frm.doc.gateway);
+									frappe.model.set_value(row.doctype, row.name, "paid_amount", frm.doc.paid_amount);
+									frappe.model.set_value(row.doctype, row.name, "payment_date", frm.doc.posting_date);
+									frappe.model.set_value(row.doctype, row.name, "payment_order_status", frm.doc.payment_order_status);
+									
+									frappe.db.get_value("Sales Order", so.name, [
+										"order_number",
+										"split_order_group_name"
+									], (so_data) => {
+										if (so_data) {
+											frappe.model.set_value(row.doctype, row.name, "order_number", so_data.order_number);
+											frappe.model.set_value(row.doctype, row.name, "split_order_group_name", so_data.split_order_group_name);
+										}
+									});
+								}
+							}
+						});
+					});
+
+					frm.refresh_field("references");
+					frm.events.set_total_allocated_amount(frm);
+				}
+			}
+		});
 	},
 
 	apply_tax_withholding_amount: function (frm) {
@@ -1097,6 +1171,11 @@ frappe.ui.form.on("Payment Entry", {
 	},
 
 	paid_amount: function (frm) {
+		if (frm.doc.party && frm.doc.paid_amount) {
+			frm.events.auto_populate_sales_orders(frm);
+		}
+		
+		// Original logic
 		frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 		if (!frm.doc.received_amount) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4109,6 +4109,7 @@ def get_sales_orders_for_auto_populate(company, customer):
 		WHERE company = %(company)s
 		AND customer = %(customer)s
 		AND cancelled_status = "Uncancelled"
+		AND financial_status IN ("Pending", "Partially Paid")
 		AND grand_total > 0
 		ORDER BY modified DESC
 		""",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4099,6 +4099,26 @@ def get_sales_orders_for_payment(doctype, txt, searchfield, start, page_len, fil
 		},
 	)
 
+
+@frappe.whitelist()
+def get_sales_orders_for_auto_populate(company, customer):
+	return frappe.db.sql(
+		"""
+		SELECT name, FORMAT(grand_total, 0) as grand_total, order_number, customer_name
+		FROM `tabSales Order`
+		WHERE company = %(company)s
+		AND customer = %(customer)s
+		AND cancelled_status = "Uncancelled"
+		AND grand_total > 0
+		ORDER BY modified DESC
+		""",
+		{
+			"company": company,
+			"customer": customer,
+		},
+		as_dict=True
+	)
+
 def cancel_pending_transfers():
 	from frappe.utils import add_to_date, now_datetime
 

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -85,7 +85,8 @@
    "label": "Paid Amount",
    "columns": 2,
    "read_only": 1,
-   "options": "currency"
+   "options": "currency",
+   "precision": "0"
   },
   {
    "fieldname": "payment_date",


### PR DESCRIPTION
### **User description**
#### Changes
- Auto-populate reference rows when creating a Payment Entry
- For demonstration, please refer to the ticket URL below

#### Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=eb958dc6-00e8-4ade-9ea8-312fe05225dd&suite_entity_num=t117546)


___

### **PR Type**
Enhancement


___

### **Description**
- Auto-populate payment entry references with unpaid sales orders

- Fetch and display sales orders matching company and customer

- Set allocated amounts intelligently based on order count

- Add zero precision formatting to paid amount field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Payment Entry Form"] -->|"party & paid_amount set"| B["auto_populate_sales_orders"]
  B -->|"fetch unpaid orders"| C["get_sales_orders_for_auto_populate"]
  C -->|"return matching SO"| D["Populate references table"]
  D -->|"single order"| E["Set full allocated amount"]
  D -->|"multiple orders"| F["Set zero allocated amount"]
  G["get_reference_details"] -->|"enrich row data"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry.py</strong><dd><code>Add function to fetch unpaid sales orders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.py

<ul><li>Added new <code>get_sales_orders_for_auto_populate()</code> function to fetch <br>unpaid sales orders<br> <li> Queries sales orders filtered by company, customer, uncancelled <br>status, and positive grand total<br> <li> Returns formatted results with name, grand_total, order_number, and <br>customer_name<br> <li> Orders results by modified date in descending order</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/236/files#diff-a7f7fdc2db51fe011675d0f9a7fb593cd56720070ddea9b391b6c3f816fe140e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>payment_entry.js</strong><dd><code>Implement auto-population logic for sales order references</code></dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry/payment_entry.js

<ul><li>Added <code>auto_populate_sales_orders()</code> event handler to automatically <br>populate references table<br> <li> Clears existing references and fetches matching sales orders via <br>server call<br> <li> Intelligently allocates amounts: full amount for single order, zero <br>for multiple orders<br> <li> Enriches each reference row with details via <code>get_reference_details()</code> <br>call<br> <li> Sets additional fields including mode_of_payment, gateway, <br>payment_date, and order metadata<br> <li> Triggers auto-population when <code>paid_amount</code> field changes and party is <br>set</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/236/files#diff-945a4747de34888d5385f1d4f57527e391be523af96a104c2a49792206c89726">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_entry_reference.json</strong><dd><code>Add zero precision to paid amount field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json

<ul><li>Added <code>"precision": "0"</code> configuration to the <code>paid_amount</code> field<br> <li> Ensures paid amount displays with zero decimal places for cleaner <br>formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/236/files#diff-22d3bb3c8d41f7f19ef7351db108cc97e1ef912151537e5e34c09c33f5302891">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

