### PR TITLE
feature(payment-entry): quick re create cancelled payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -452,6 +452,37 @@ frappe.ui.form.on("Payment Entry", {
 			}, qr_group);
 		}
 
+		// Quick Re-create button for Cancelled Banking PEs
+		if (frm.doc.docstatus === 2) {
+			frm.events.get_payment_code(frm, (payment_code) => {
+				if (payment_code === "banking") {
+					frm.add_custom_button(__("Tạo lại phiếu nhanh"), function() {
+						frappe.call({
+							method: "erpnext.accounts.doctype.payment_entry.payment_entry.recreate_payment_entry",
+							args: {
+								payment_entry_name: frm.doc.name
+							},
+							freeze: true,
+							freeze_message: __("Đang tạo phiếu mới và map giao dịch ngân hàng"),
+							callback: function(r) {
+								if (r.message) {
+									if (r.message.name) {
+										frappe.set_route("Form", "Payment Entry", r.message.name);
+									}
+									if (r.message.alert) {
+										frappe.show_alert({
+											message: r.message.alert,
+											indicator: r.message.indicator || 'orange'
+										});
+									}
+								}
+							}
+						});
+					}).addClass("btn-primary");
+				}
+			});
+		}
+
 		// Add Verify button
 		if (
 			!frm.is_new() &&

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -261,7 +261,7 @@ frappe.ui.form.on("Payment Entry", {
 			callback(null);
 			return;
 		}
-		
+
 		frappe.db.get_value("Mode of Payment", frm.doc.mode_of_payment, "payment_code", (r) => {
 			callback(r ? r.payment_code : null);
 		});
@@ -333,15 +333,15 @@ frappe.ui.form.on("Payment Entry", {
 
 		frm.events.get_payment_code(frm, (payment_code) => {
 			frm.toggle_display("gateway", ["payment_link", "pos", "cash", "cash_on_delivery"].includes(payment_code));
-			
+
 			const show_bank_account = payment_code && !["cash", "pos", "payment_link", "cash_on_delivery"].includes(payment_code);
 			frm.toggle_display("bank_account", show_bank_account);
-			
+
 			const is_new_or_has_bank = frm.is_new() || frm.doc.bank_account;
 			const make_required = show_bank_account && frm.doc.docstatus === 0 && is_new_or_has_bank;
 			frm.set_df_property("bank_account", "reqd", make_required ? 1 : 0);
 			frm.toggle_display("qr_section_break", payment_code === "banking");
-			
+
 			const payment_date_required = !["cash_on_delivery"].includes(payment_code);
 			frm.set_df_property("payment_date", "reqd", payment_date_required ? 1 : 0);
 		});
@@ -351,7 +351,7 @@ frappe.ui.form.on("Payment Entry", {
 		if (frm.doc.docstatus === 0) {
 			if (frm.page.btn_primary) {
 				frm.page.btn_primary.hide();
-			}			
+			}
 			frm.page.remove_inner_button(__("Submit"));
 		}
 	},
@@ -460,7 +460,7 @@ frappe.ui.form.on("Payment Entry", {
 			(frappe.user.has_role("Accounts User") || frappe.user.has_role("Accounts Manager"))
 		) {
 			let has_sales_order = frm.doc.references && frm.doc.references.some(ref => ref.reference_doctype === "Sales Order");
-			
+
 			let btn = frm.add_custom_button(__("Verify"), () => {
 				frm.events.get_payment_code(frm, (payment_code) => {
 					let requires_bank_transaction = payment_code === "banking";
@@ -493,7 +493,7 @@ frappe.ui.form.on("Payment Entry", {
 					});
 				});
 			});
-			
+
 			if (!has_sales_order) {
 				btn.addClass('disabled').prop('disabled', true);
 			}
@@ -522,7 +522,7 @@ frappe.ui.form.on("Payment Entry", {
 		for (let bt of frm.doc.bank_transactions) {
 			if (bt.allocated_amount && frm.doc.paid_amount) {
 				if (Math.abs(flt(bt.allocated_amount) - flt(frm.doc.paid_amount)) > 0.01) {
-					frappe.throw(__("Số tiền phân bổ của giao dịch ngân hàng ({0}) phải khớp với số tiền thanh toán của phiếu ({1}).", 
+					frappe.throw(__("Số tiền phân bổ của giao dịch ngân hàng ({0}) phải khớp với số tiền thanh toán của phiếu ({1}).",
 						[bt.allocated_amount, frm.doc.paid_amount]));
 				}
 			}
@@ -721,7 +721,7 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_value("gateway", "");
 		frm.events.update_gateway_options(frm);
 		frm.events.update_field_visibility(frm);
-		
+
 		if (frm.doc.mode_of_payment) {
 			frappe.db.get_value("Mode of Payment", frm.doc.mode_of_payment, "payment_code", (r) => {
 				if (r && r.payment_code) {
@@ -729,7 +729,7 @@ frappe.ui.form.on("Payment Entry", {
 				}
 			});
 		}
-		
+
 		if (frm.doc.references && frm.doc.references.length > 0) {
 			frm.doc.references.forEach(function(row) {
 				if (row.reference_doctype === "Sales Order") {
@@ -738,7 +738,7 @@ frappe.ui.form.on("Payment Entry", {
 			});
 			frm.refresh_field("references");
 		}
-		
+
 		erpnext.accounts.pos.get_payment_mode_account(frm, frm.doc.mode_of_payment, function (account) {
 			let payment_account_field = frm.doc.payment_type == "Receive" ? "paid_to" : "paid_from";
 			frm.set_value(payment_account_field, account);
@@ -917,8 +917,8 @@ frappe.ui.form.on("Payment Entry", {
 							args: {
 								reference_doctype: "Sales Order",
 								reference_name: so.name,
-								party_account_currency: frm.doc.payment_type == "Receive" 
-									? frm.doc.paid_from_account_currency 
+								party_account_currency: frm.doc.payment_type == "Receive"
+									? frm.doc.paid_from_account_currency
 									: frm.doc.paid_to_account_currency,
 								party_type: frm.doc.party_type,
 								party: frm.doc.party,
@@ -934,7 +934,7 @@ frappe.ui.form.on("Payment Entry", {
 									frappe.model.set_value(row.doctype, row.name, "paid_amount", frm.doc.paid_amount);
 									frappe.model.set_value(row.doctype, row.name, "payment_date", frm.doc.payment_date);
 									frappe.model.set_value(row.doctype, row.name, "payment_order_status", frm.doc.payment_order_status);
-									
+
 									frappe.db.get_value("Sales Order", so.name, [
 										"order_number",
 										"split_order_group_name"
@@ -1198,7 +1198,7 @@ frappe.ui.form.on("Payment Entry", {
 		if (frm.doc.party && frm.doc.paid_amount) {
 			frm.events.auto_populate_sales_orders(frm);
 		}
-		
+
 		// Original logic
 		frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
@@ -2250,7 +2250,7 @@ frappe.ui.form.on("Payment Entry Reference", {
 
 							frappe.model.set_value(cdt, cdn, "allocated_amount", allocated_amount);
 						}
-						
+
 						if (row.reference_doctype === "Sales Order") {
 							frappe.model.set_value(cdt, cdn, "mode_of_payment", frm.doc.mode_of_payment);
 							frappe.model.set_value(cdt, cdn, "gateway", frm.doc.gateway);
@@ -2267,7 +2267,7 @@ frappe.ui.form.on("Payment Entry Reference", {
 								}
 							});
 						}
-						
+
 						frm.refresh_fields();
 					}
 				},
@@ -2428,7 +2428,7 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 	},
 
 	allocated_amount: function(frm, cdt, cdn) {
-		let row = locals[cdt][cdn];		
+		let row = locals[cdt][cdn];
 		if (row.allocated_amount && frm.doc.paid_amount) {
 			if (Math.abs(flt(row.allocated_amount) - flt(frm.doc.paid_amount)) > 0.01) {
 				frappe.msgprint({
@@ -2436,7 +2436,7 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 					message: __("Vui lòng kiểm tra và nhập <b>đúng số tiền thanh toán trước</b> khi tiếp tục.", [frm.doc.paid_amount]),
 					indicator: 'red'
 				});
-				
+
 				frappe.model.clear_doc(cdt, cdn);
 				frm.refresh_field("bank_transactions");
 			}
@@ -2450,14 +2450,14 @@ frappe.ui.form.on("Payment Entry Bank Transaction", {
 				indicator: "red",
 				message: __("Mỗi phiếu thanh toán chỉ được phép gắn <b>một giao dịch duy nhất</b>.")
 			});
-			
+
 			setTimeout(() => {
 				frappe.model.clear_doc(cdt, cdn);
 				frm.refresh_field("bank_transactions");
 			}, 100);
 			return;
 		}
-		
+
 		let row = locals[cdt][cdn];
 		if (frm.doc.paid_amount) {
 			frappe.model.set_value(cdt, cdn, "allocated_amount", frm.doc.paid_amount);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -320,7 +320,7 @@ class PaymentEntry(AccountsController):
 		validate_docs_for_voucher_types(["Payment Entry"])
 		validate_docs_for_deferred_accounting([self.name], [])
 
-	def on_update_after_submit(self):		
+	def on_update_after_submit(self):
 		# Flag will be set on Reconciliation
 		# Reconciliation tool will anyways repost ledger entries. So, no need to check and do implicit repost.
 		if self.flags.get("ignore_reposting_on_reconciliation"):
@@ -802,7 +802,7 @@ class PaymentEntry(AccountsController):
 		for field in ("paid_amount", "received_amount", "source_exchange_rate", "target_exchange_rate"):
 			if not self.get(field):
 				frappe.throw(_("{0} is mandatory").format(self.meta.get_label(field)))
-		
+
 		if not self.payment_date and self.payment_code != "cash_on_delivery":
 			frappe.throw(_("Payment Date is mandatory"))
 
@@ -1462,9 +1462,9 @@ class PaymentEntry(AccountsController):
 		for ref in self.get("references"):
 			if ref.allocated_amount or ref.reference_doctype == "Sales Order":
 				filtered_references.append(ref)
-		
+
 		self.set("references", filtered_references)
-		
+
 		frappe.db.sql(
 			"""delete from `tabPayment Entry Reference`
 			where parent = %s and allocated_amount = 0 and reference_doctype != 'Sales Order'""",
@@ -2162,9 +2162,9 @@ class PaymentEntry(AccountsController):
 		"""Get payment code from mode of payment"""
 		if not self.mode_of_payment:
 			return None
-		
+
 		return frappe.db.get_value("Mode of Payment", self.mode_of_payment, "payment_code")
-	
+
 	def set_payment_code(self):
 		if self.mode_of_payment:
 			self.payment_code = self.get_payment_code()
@@ -2172,19 +2172,19 @@ class PaymentEntry(AccountsController):
 	@frappe.whitelist()
 	def verify_payment(self):
 		"""Verify payment entry after bank transaction matching"""
-		payment_code = self.get_payment_code()		
+		payment_code = self.get_payment_code()
 		requires_bank_transaction = payment_code == "banking"
-		
+
 		if requires_bank_transaction and (not self.bank_transactions or len(self.bank_transactions) == 0):
 			frappe.throw(_("Cannot verify: Banking payment must have at least one Bank Transaction"))
-		
+
 		has_sales_order = any(ref.reference_doctype == "Sales Order" for ref in self.references)
 		if not has_sales_order:
 			frappe.throw(_("Cannot verify: Payment Entry must have at least one Sales Order reference"))
 
 		if not self.verified_by:
 			self.verified_by = frappe.session.user
-		
+
 		self.save()
 
 		frappe.msgprint(_("Payment Entry verified successfully"))
@@ -3921,7 +3921,7 @@ def get_customer_with_phone(doctype, txt, searchfield, start, page_len, filters)
 			OR phone LIKE %(txt)s
 		)
 		ORDER BY
-			CASE 
+			CASE
 				WHEN name LIKE %(txt)s THEN 0
 				WHEN customer_name LIKE %(txt)s THEN 1
 				ELSE 2
@@ -4067,7 +4067,7 @@ def cancel_pending_transfers():
 			doc.flags.ignore_permissions = True
 			doc.flags.ignore_validate = True
 			doc.save()
-			
+
 			frappe.db.sql("""
 				UPDATE `tabPayment Entry`
 				SET docstatus = 2,
@@ -4182,7 +4182,7 @@ def daily_run_success_batch():
 		filters={"enabled": 1, "webhook_doctype": "Payment Entry"},
 		fields=["name"]
 	)
-	
+
 	webhook = None
 	for wh in webhooks:
 		w = frappe.get_doc("Webhook", wh.name)
@@ -4226,5 +4226,5 @@ def daily_run_success_batch():
 			frappe.log_error(
 				f"Failed to trigger webhook for Payment Entry {pe_name}: {str(e)}",
 				"Payment Entry Webhook Trigger Error"
-			)		
+			)
 		time.sleep(1)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4176,6 +4176,84 @@ def get_payment_entry_list(doctype=None, txt="", searchfield="name", start=0, pa
 
 	return frappe.db.sql(query, values, as_dict=True)
 
+@frappe.whitelist()
+def recreate_payment_entry(payment_entry_name):
+	from frappe.utils import now_datetime, nowdate, flt
+
+	doc = frappe.get_doc("Payment Entry", payment_entry_name)
+
+	if doc.docstatus != 2:
+		frappe.throw(_("Chỉ có thể tạo lại phiếu từ phiếu đã huỷ"))
+
+	new_doc = frappe.copy_doc(doc)
+	new_doc.amended_from = None
+	new_doc.docstatus = 0
+	new_doc.payment_date = now_datetime()
+	new_doc.posting_date = nowdate()
+	new_doc.payment_order_status = 'Pending'
+
+	for field in new_doc.meta.fields:
+		if field.fieldname.startswith("custom_") or field.fieldname.startswith("misa_"):
+			new_doc.set(field.fieldname, None)
+
+	new_doc.custom_transaction_id = None
+	new_doc.custom_transfer_status = None
+	new_doc.qr_url = None
+	new_doc.save()
+	frappe.db.commit()
+
+	time.sleep(6)
+	alert_message = None
+	alert_indicator = "orange"
+	transfer_note = doc.custom_transfer_note
+	amount = flt(doc.paid_amount)
+	if transfer_note:
+		fields_to_search = [
+			"description",
+			"sepay_transaction_content",
+			"sepay_order_description",
+			"sepay_order_number"
+		]
+
+		conditions = " OR ".join([f"{field} LIKE %s" for field in fields_to_search])
+		query = f"""
+			SELECT name
+			FROM `tabBank Transaction`
+			WHERE ({conditions})
+			LIMIT 1
+		"""
+		params = [f"%{transfer_note}%"] * len(fields_to_search)
+		bank_transactions = frappe.db.sql(query, tuple(params), as_dict=True)
+
+		if bank_transactions:
+			bt_name = bank_transactions[0].name
+			bt = frappe.get_doc("Bank Transaction", bt_name)
+
+			if flt(bt.sepay_amount_in) == amount:
+				if bt.payment_entries:
+					alert_message = _("Giao dịch ngân hàng có nội dung chuyển khoản của phiếu cũ đã được map với phiếu khác")
+					alert_indicator = "orange"
+				else:
+					bt.append("payment_entries", {
+						"payment_document": "Payment Entry",
+						"payment_entry": new_doc.name,
+						"allocated_amount": amount
+					})
+					bt.save()
+					alert_message = _("Tạo và map giao dịch ngân hàng thành công")
+					alert_indicator = "green"
+			else:
+				alert_message = _("Không tìm thấy giao dịch ngân hàng khớp số tiền: '{0}' và nội dung: '{1}'. Vui lòng map thủ công.").format(amount, transfer_note)
+				alert_indicator = "red"
+		else:
+			alert_message = _("Không tìm thấy giao dịch ngân hàng khớp số tiền: '{0}' và nội dung: '{1}'. Vui lòng map thủ công.").format(amount, transfer_note)
+			alert_indicator = "red"
+	else:
+		alert_message = _("Thiếu nội dung chuyển khoản ở phiếu cũ")
+		alert_indicator = "red"
+
+	return { "name": new_doc.name, "alert": alert_message, "indicator": alert_indicator }
+
 def daily_run_success_batch():
 	webhooks = frappe.get_all(
 		"Webhook",


### PR DESCRIPTION
#### Changes
- Added `Quick re-create PE` button for cancelled PE
  - Automatically mapping Bank Transaction if have any based on the old cancelled transfer_note

- For image and video demo, please refer to ticket link below

##### Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=f37182f4-ba0d-414e-919f-20584dfafa9d&suite_entity_num=t116959)