### PR TITLE
bug(payment-entry): added missing order_number and split_order_number

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -276,7 +276,7 @@ class SalesOrder(SellingController):
 		payment_references = frappe.db.sql("""
 			SELECT
 				pr.name, pr.parenttype, pr.parent, pr.reference_doctype, pr.reference_name,
-				pr.total_amount, pr.outstanding_amount,
+				pr.total_amount, pr.outstanding_amount, pr.order_number, pr.split_order_group_name,
 				CASE
 					WHEN pe.payment_type = 'Pay' THEN -pr.allocated_amount
 					ELSE pr.allocated_amount
@@ -314,7 +314,9 @@ class SalesOrder(SellingController):
 					"gateway": pe_ref.gateway,
 					"paid_amount": pe_ref.paid_amount,
 					"payment_date": pe_ref.payment_date,
-					"payment_order_status": pe_ref.payment_order_status
+					"payment_order_status": pe_ref.payment_order_status,
+					"order_number": pe_ref.order_number,
+					"split_order_group_name": pe_ref.split_order_group_name,
 			})
 
 
@@ -335,7 +337,7 @@ class SalesOrder(SellingController):
 		payment_references = frappe.db.sql("""
 			SELECT
 				pr.name, pr.parenttype, pr.parent, pr.reference_doctype, pr.reference_name,
-				pr.total_amount, pr.outstanding_amount,
+				pr.total_amount, pr.outstanding_amount, pr.order_number, pr.split_order_group_name,
 				CASE
 					WHEN pe.payment_type = 'Pay' THEN -pr.allocated_amount
 					ELSE pr.allocated_amount
@@ -372,7 +374,9 @@ class SalesOrder(SellingController):
 						"gateway": pe_ref.gateway,
 						"paid_amount": pe_ref.paid_amount,
 						"payment_date": pe_ref.payment_date,
-						"payment_order_status": pe_ref.payment_order_status
+						"payment_order_status": pe_ref.payment_order_status,
+						"order_number": pe_ref.order_number,
+						"split_order_group_name": pe_ref.split_order_group_name
 				})
 
 	def get_all_related_sales_orders(self):


### PR DESCRIPTION
### **User description**
#### Changes
- Added missing order_number and split_order_number_name for sales order


___

### **PR Type**
Bug fix


___

### **Description**
- Added missing `order_number` and `split_order_group_name` fields to payment entry queries

- Included these fields in both `set_payment_entries()` and `set_group_payment_entries()` methods

- Ensures payment entry references contain complete order tracking information


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sales Order Payment Methods"] --> B["set_payment_entries()"]
  A --> C["set_group_payment_entries()"]
  B --> D["SQL Query + order_number, split_order_group_name"]
  C --> E["SQL Query + order_number, split_order_group_name"]
  D --> F["Payment Entry Reference with order fields"]
  E --> G["Group Payment Entry Reference with order fields"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sales_order.py</strong><dd><code>Add order number fields to payment entry references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/selling/doctype/sales_order/sales_order.py

<ul><li>Added <code>order_number</code> and <code>split_order_group_name</code> to SQL SELECT clause in <br><code>set_payment_entries()</code> method<br> <li> Added <code>order_number</code> and <code>split_order_group_name</code> fields to payment entry <br>reference dictionary in <code>set_payment_entries()</code><br> <li> Added <code>order_number</code> and <code>split_order_group_name</code> to SQL SELECT clause in <br><code>set_group_payment_entries()</code> method<br> <li> Added <code>order_number</code> and <code>split_order_group_name</code> fields to group payment <br>entry reference dictionary in <code>set_group_payment_entries()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/277/files#diff-3581fbb34fe59d53d3aedbcd7c810e6c3dd56ec9d100b8362c85471ef08879f1">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

