### PR TITLE
fix: strictly check null / empty

### DIFF
--- a/erpnext/crm/doctype/lead/lead_dao.py
+++ b/erpnext/crm/doctype/lead/lead_dao.py
@@ -1,5 +1,6 @@
 import frappe
 
+
 def get_lead_name_by_conversation_id(conversation_id: str):
 	names = frappe.get_all(
 		"Contact",

--- a/erpnext/crm/doctype/lead/lead_methods.py
+++ b/erpnext/crm/doctype/lead/lead_methods.py
@@ -32,8 +32,16 @@ def insert_lead_by_batch(docs=None):
 
 	result = []
 	for doc in docs:
+		doc = doc.copy()
 		pancake_data = doc.get("pancake_data", {})
 		conversation_id = pancake_data.get("conversation_id")
+		if not conversation_id or not conversation_id.strip():
+			result.append({
+				"name": None,
+				"conversation_id": conversation_id
+			})
+			continue
+
 		try:
 			inserted_doc = insert_lead(doc)
 			if inserted_doc:
@@ -84,7 +92,7 @@ def insert_lead(doc) -> "Document":
 	page_id = pancake_data.get("page_id")
 	conversation_id = pancake_data.get("conversation_id")
 
-	if conversation_id:
+	if conversation_id and conversation_id.strip():
 		existing_lead_name = get_lead_name_by_conversation_id(conversation_id)
 		if existing_lead_name:
 			existing_doc: Lead = frappe.get_doc("Lead", existing_lead_name)
@@ -94,7 +102,7 @@ def insert_lead(doc) -> "Document":
 			return existing_doc
 
 	# Check if lead exists by phone
-	if is_valid_phone and pancake_phone:
+	if is_valid_phone and pancake_phone and pancake_phone.strip():
 		existing_lead_name = frappe.db.get_value("Lead", {"phone": pancake_phone}, "name")
 		if existing_lead_name:
 			existing_doc = frappe.get_doc("Lead", existing_lead_name)
@@ -231,6 +239,7 @@ def update_lead_by_batch(docs):
 	failed_docs = []
 	results = []
 	for doc in docs:
+		doc = doc.copy()
 		doc.pop("flags", None)
 		pancake_data = doc.get("pancake_data", {})
 		try:
@@ -243,7 +252,7 @@ def update_lead_by_batch(docs):
 				existing_doc = frappe.get_doc(doc["doctype"], doc["docname"])
 			except (frappe.DoesNotExistError, Exception):
 				conversation_id = pancake_data.get("conversation_id")
-				lead_name = get_lead_name_by_conversation_id(conversation_id) if conversation_id else None
+				lead_name = get_lead_name_by_conversation_id(conversation_id) if conversation_id and conversation_id.strip() else None
 
 				if lead_name:
 					existing_doc = frappe.get_doc(doc["doctype"], lead_name)
@@ -256,7 +265,7 @@ def update_lead_by_batch(docs):
 
 			# Check if the new phone number already exists in another lead
 			new_phone = doc.get("phone")
-			if new_phone:
+			if new_phone and new_phone.strip():
 				existing_doc = handle_duplicate_and_merge(
 					existing_doc,
 					new_phone
@@ -302,6 +311,9 @@ def handle_duplicate_and_merge(existing_doc, new_phone):
 	If so, keep the oldest lead (by first_reach_at), merge contacts, and delete the duplicate.
 	Returns the 'master' document that survived.
 	"""
+	if not new_phone or not new_phone.strip():
+		return existing_doc
+
 	conflicting_lead = frappe.db.get_value("Lead", {"phone": new_phone}, "name")
 
 	if not conflicting_lead or conflicting_lead == existing_doc.name:
@@ -372,7 +384,7 @@ def update_lead_from_summary(data):
 		data = frappe.parse_json(data)
 
 	conversation_id = data.get("conversation_id")
-	if not conversation_id:
+	if not conversation_id or not conversation_id.strip():
 		return
 
 	lead_name = get_lead_name_by_conversation_id(conversation_id)

--- a/erpnext/crm/doctype/lead/lead_methods.py
+++ b/erpnext/crm/doctype/lead/lead_methods.py
@@ -40,7 +40,6 @@ def insert_lead_by_batch(docs=None):
 		conversation_id = pancake_data.get("conversation_id")
 
 		if not is_non_empty(conversation_id):
-			conversation_id = None
 			frappe.logger().warning(
 				"insert_lead_by_batch: missing conversation_id",
 				exc_info=False

--- a/erpnext/crm/doctype/lead/lead_methods.py
+++ b/erpnext/crm/doctype/lead/lead_methods.py
@@ -19,6 +19,9 @@ from erpnext.crm.doctype.lead_product.lead_product_dao import create_lead_produc
 if TYPE_CHECKING:
 	from frappe.model.document import Document
 
+def is_non_empty(value: str | None) -> bool:
+	return bool(value and value.strip())
+
 @frappe.whitelist(methods=["POST", "PUT"])
 def insert_lead_by_batch(docs=None):
 	"""Insert multiple lead
@@ -35,7 +38,13 @@ def insert_lead_by_batch(docs=None):
 		doc = doc.copy()
 		pancake_data = doc.get("pancake_data", {})
 		conversation_id = pancake_data.get("conversation_id")
-		if not conversation_id or not conversation_id.strip():
+
+		if not is_non_empty(conversation_id):
+			conversation_id = None
+			frappe.logger().warning(
+				"insert_lead_by_batch: missing conversation_id",
+				exc_info=False
+			)
 			result.append({
 				"name": None,
 				"conversation_id": conversation_id
@@ -92,7 +101,7 @@ def insert_lead(doc) -> "Document":
 	page_id = pancake_data.get("page_id")
 	conversation_id = pancake_data.get("conversation_id")
 
-	if conversation_id and conversation_id.strip():
+	if is_non_empty(conversation_id):
 		existing_lead_name = get_lead_name_by_conversation_id(conversation_id)
 		if existing_lead_name:
 			existing_doc: Lead = frappe.get_doc("Lead", existing_lead_name)
@@ -102,7 +111,7 @@ def insert_lead(doc) -> "Document":
 			return existing_doc
 
 	# Check if lead exists by phone
-	if is_valid_phone and pancake_phone and pancake_phone.strip():
+	if is_valid_phone and is_non_empty(pancake_phone):
 		existing_lead_name = frappe.db.get_value("Lead", {"phone": pancake_phone}, "name")
 		if existing_lead_name:
 			existing_doc = frappe.get_doc("Lead", existing_lead_name)
@@ -176,7 +185,7 @@ def backfill_lead_info(docs):
             ids_to_update.append(lead_id)
 
             # Build CASE WHEN clauses for first_name with nested conditions
-            if new_name:  # Only add clause if new_name is not empty
+            if is_non_empty(new_name):  # Only add clause if new_name is not empty
                 name_case_when_clauses.append("""
                     WHEN name = %s THEN
                         CASE
@@ -188,7 +197,7 @@ def backfill_lead_info(docs):
                 sql_params_name.extend([lead_id, new_name])
 
             # Build CASE WHEN clauses for phone with nested conditions
-            if new_phone:  # Only add clause if new_phone is not empty
+            if is_non_empty(new_phone):  # Only add clause if new_phone is not empty
                 phone_case_when_clauses.append("""
                     WHEN name = %s THEN
                         CASE
@@ -252,7 +261,7 @@ def update_lead_by_batch(docs):
 				existing_doc = frappe.get_doc(doc["doctype"], doc["docname"])
 			except (frappe.DoesNotExistError, Exception):
 				conversation_id = pancake_data.get("conversation_id")
-				lead_name = get_lead_name_by_conversation_id(conversation_id) if conversation_id and conversation_id.strip() else None
+				lead_name = get_lead_name_by_conversation_id(conversation_id) if is_non_empty(conversation_id) else None
 
 				if lead_name:
 					existing_doc = frappe.get_doc(doc["doctype"], lead_name)
@@ -265,7 +274,7 @@ def update_lead_by_batch(docs):
 
 			# Check if the new phone number already exists in another lead
 			new_phone = doc.get("phone")
-			if new_phone and new_phone.strip():
+			if is_non_empty(new_phone):
 				existing_doc = handle_duplicate_and_merge(
 					existing_doc,
 					new_phone
@@ -311,7 +320,7 @@ def handle_duplicate_and_merge(existing_doc, new_phone):
 	If so, keep the oldest lead (by first_reach_at), merge contacts, and delete the duplicate.
 	Returns the 'master' document that survived.
 	"""
-	if not new_phone or not new_phone.strip():
+	if not is_non_empty(new_phone):
 		return existing_doc
 
 	conflicting_lead = frappe.db.get_value("Lead", {"phone": new_phone}, "name")
@@ -384,7 +393,11 @@ def update_lead_from_summary(data):
 		data = frappe.parse_json(data)
 
 	conversation_id = data.get("conversation_id")
-	if not conversation_id or not conversation_id.strip():
+	if not is_non_empty(conversation_id):
+		frappe.logger().warning(
+			"update_lead_from_summary: missing conversation_id",
+			exc_info=False
+		)
 		return
 
 	lead_name = get_lead_name_by_conversation_id(conversation_id)


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Bug fix


___

### **Description**
- Add strict null and empty string validation for conversation_id

- Add strict validation for phone numbers before processing

- Prevent processing of whitespace-only strings as valid data

- Create document copies in batch operations to avoid mutations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input Data"] --> B["Check for null/empty"]
  B --> C["Validate strip whitespace"]
  C --> D{Valid Data?}
  D -->|Yes| E["Process Lead"]
  D -->|No| F["Skip/Return Early"]
  E --> G["Result"]
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead_dao.py</strong><dd><code>Minor formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead_dao.py

- Add blank line for code formatting consistency


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/279/files#diff-4e50f6e0788d5f9f0fbf3972e7b846e0207c196ae37d226b65c3511aae109977">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lead_methods.py</strong><dd><code>Implement strict null and empty validation throughout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erpnext/crm/doctype/lead/lead_methods.py

<ul><li>Add strict validation for <code>conversation_id</code> using <code>strip()</code> check in <br><code>insert_lead_by_batch()</code><br> <li> Add early return with null name when conversation_id is empty or <br>whitespace-only<br> <li> Create document copy before processing to prevent input mutation in <br>batch operations<br> <li> Add <code>strip()</code> validation for <code>conversation_id</code> in <code>insert_lead()</code> function<br> <li> Add <code>strip()</code> validation for <code>pancake_phone</code> in phone duplicate check<br> <li> Add strict validation in <code>update_lead_by_batch()</code> for conversation_id <br>lookup<br> <li> Add <code>strip()</code> validation for <code>new_phone</code> before duplicate handling<br> <li> Add early return guard in <code>handle_duplicate_and_merge()</code> for empty phone <br>values<br> <li> Add strict validation for <code>conversation_id</code> in <br><code>update_lead_from_summary()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erpnext/pull/279/files#diff-bb9e795b0f2b4cbb93d5dbcf3ee4fafe091c8b84e1f121273fec7d9d15e291b3">+17/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

