### PR TITLE
Fix/bank transaction/prevent bank mismatch link to payment entry

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -149,6 +149,9 @@ class BankTransaction(Document):
 			if pe_row.payment_document == "Payment Entry" and pe_row.payment_entry:
 				try:
 					payment_entry = frappe.get_doc("Payment Entry", pe_row.payment_entry)
+					if payment_entry.bank_account_no != self.sepay_account_number:
+						continue
+
 					existing = any(
 						bt.bank_transaction == self.name
 						for bt in payment_entry.bank_transactions

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -967,7 +967,12 @@ class PaymentEntry(AccountsController):
 
 			sepay_account_number = frappe.db.get_value("Bank Transaction", bt.bank_transaction, "sepay_account_number")
 			if sepay_account_number and self.bank_account_no and self.bank_account_no != sepay_account_number:
-				frappe.throw(_("STK ngân hàng của phiếu thanh toán không khớp STK ngân hàng của giao dịch ngân hàng"))
+				msg = _("STK ngân hàng của phiếu thanh toán không khớp STK ngân hàng của giao dịch ngân hàng")
+				msg += "<br><br>"
+				msg += _("1. Bạn cần phải thay đổi <b>Tài khoản ngân hàng</b> đúng với Ngân hàng của phiếu <b>Giao dịch ngân hàng</b>. Bấm <b>Lưu</b>") + "<br>"
+				msg += _("2. Sau đó map <b>Giao dịch ngân hàng</b> và bấm <b>Lưu</b>") + "<br><br>"
+				msg += _("<b>Lưu ý: Nếu bạn không làm được, hãy nhắn gửi tin nhắn đến nhóm hỗ trợ nhé!</b>")
+				frappe.throw(msg)
 
 	def update_payment_schedule(self, cancel=0):
 		invoice_payment_amount_map = {}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -965,6 +965,10 @@ class PaymentEntry(AccountsController):
 			if not bt.bank_transaction:
 				frappe.throw(_("Dòng #{0}: Bắt buộc chọn Giao dịch ngân hàng").format(bt.idx))
 
+			sepay_account_number = frappe.db.get_value("Bank Transaction", bt.bank_transaction, "sepay_account_number")
+			if sepay_account_number and self.bank_account_no and self.bank_account_no != sepay_account_number:
+				frappe.throw(_("STK ngân hàng của phiếu thanh toán không khớp STK ngân hàng của giao dịch ngân hàng"))
+
 	def update_payment_schedule(self, cancel=0):
 		invoice_payment_amount_map = {}
 		invoice_paid_amount_map = {}


### PR DESCRIPTION
#### Changes
- Prevent Bank transaction automatically or manually link to payment entry, if bank_account_number is mismatch
  - Sales person need to update bank info in PE first, in order to update/ mapping the Bank tranasction into payment entry