### PR TITLE
chore(payment-entry): calling sync SO payment_entries directly instea…

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -295,11 +295,7 @@ class PaymentEntry(AccountsController):
 
 	def on_update(self):
 		self.sync_bank_transaction_payments()
-		frappe.enqueue(
-			"erpnext.accounts.doctype.payment_entry.payment_entry.sync_so_snapshot_pe_fields_background",
-			queue="short",
-			pe_name=self.name
-		)
+		sync_so_snapshot_pe_fields_background(self.name)
 
 	def sync_bank_transaction_payments(self):
 		if self.flags.get("updating_from_bank_transaction"):


### PR DESCRIPTION
#### Changes
- Calling the sync SO payment_entries directly instead of queuing

Ticket: [Link](https://applink.larksuite.com/client/todo/detail?guid=8a90d75e-2e61-4bfc-94d7-53e06d03869e&suite_entity_num=t119054)