### PR TITLE
chore(sales-order-item): have product availability status requried on…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -2181,3 +2181,33 @@ function render_promotion_pills(frm, cdt, cdn) {
 		$(this).css("opacity", "1");
 	});
 }
+
+frappe.ui.form.on("Sales Order Item", {
+	items_add: function(frm, cdt, cdn) {
+		frm.fields_dict.items.grid.update_docfield_property(
+			"product_availability_status",
+			"reqd",
+			1
+		);
+	},
+	
+	form_render: function(frm, cdt, cdn) {
+		frm.fields_dict.items.grid.update_docfield_property(
+			"product_availability_status",
+			"reqd",
+			1
+		);
+	}
+});
+
+frappe.ui.form.on("Sales Order", {
+	onload_post_render: function(frm) {
+		if (frm.fields_dict.items) {
+			frm.fields_dict.items.grid.update_docfield_property(
+				"product_availability_status",
+				"reqd",
+				1
+			);
+		}
+	}
+});


### PR DESCRIPTION
#### Changes
- Made Sales Order Item `Product availability status` reuqired on the UI ONLY => not blocking API create/updte flow

<img width="2376" height="916" alt="img_v3_0210k_36b61d40-4875-431e-94cb-fc0af935b9hu" src="https://github.com/user-attachments/assets/479748a3-904b-4015-8cbe-3d170a5bd6fc" />


