### PR TITLE
feature(payment-entry): added refund amount field

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -2403,7 +2403,10 @@ frappe.ui.form.on("Payment Entry Reference", {
 									: frm.doc.unallocated_amount;
 
 							frappe.model.set_value(cdt, cdn, "allocated_amount", allocated_amount);
+							let diff = flt(row.paid_amount) - flt(allocated_amount);
+							frappe.model.set_value(cdt, cdn, "unallocated_amount", diff > 0 ? diff : 0);
 						}
+
 
 						if (row.reference_doctype === "Sales Order") {
 							frappe.model.set_value(cdt, cdn, "mode_of_payment", frm.doc.mode_of_payment);
@@ -2434,7 +2437,11 @@ frappe.ui.form.on("Payment Entry Reference", {
 		}
 	},
 
-	allocated_amount: function (frm) {
+	allocated_amount: function (frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		let diff = flt(row.paid_amount) - flt(row.allocated_amount);
+		frappe.model.set_value(cdt, cdn, "unallocated_amount", diff > 0 ? diff : 0);
+		
 		frm.events.set_total_allocated_amount(frm);
 	},
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -535,6 +535,7 @@ frappe.ui.form.on("Payment Entry", {
 		await frm.events.set_exchange_gain_loss_deduction(frm);
 		frm.events.validate_bank_transactions(frm);
 		frm.events.validate_total_allocated_amount(frm);
+		frm.events.checking_refund_amount(frm);
 	},
 
 	before_save: function(frm) {
@@ -1650,7 +1651,7 @@ frappe.ui.form.on("Payment Entry", {
 		const difference = total_allocated - flt(frm.doc.paid_amount);
 		const tolerance = 1000;
 
-		if (Math.abs(difference) > tolerance) {
+		if (difference > tolerance) {
 			frappe.throw({
 				title: __("Phân bổ không hợp lệ"),
 				indicator: "red",
@@ -1659,22 +1660,88 @@ frappe.ui.form.on("Payment Entry", {
 					[
 						format_currency(frm.doc.paid_amount, frm.doc.paid_from_account_currency, 0),
 						format_currency(total_allocated, frm.doc.paid_from_account_currency, 0),
-						format_currency(Math.abs(difference), frm.doc.paid_from_account_currency, 0)
+						format_currency(difference, frm.doc.paid_from_account_currency, 0)
 					]
 				)
 			});
-		} else if (difference !== 0) {
+		} else if (difference > 0 && difference <= tolerance) {
 			frappe.show_alert({
 				message: __(
 					"Chênh lệch {0} nằm trong mức cho phép {1}.",
 					[
-						format_currency(Math.abs(difference), frm.doc.paid_from_account_currency, 0),
+						format_currency(difference, frm.doc.paid_from_account_currency, 0),
 						format_currency(tolerance, frm.doc.paid_from_account_currency, 0)
 					]
 				),
 				indicator: "blue"
 			}, 10);
 		}
+	},
+
+	checking_refund_amount: function (frm) {
+		if (!frm.doc.paid_amount || !frm.doc.references || frm.doc.references.length === 0) {
+			return;
+		}
+
+		if (frappe.user.has_role("Administrator") || frappe.user.has_role("Developer")) {
+			return;
+		}
+
+		let total_allocated = 0;
+		$.each(frm.doc.references || [], function (i, row) {
+			if (row.allocated_amount) {
+				total_allocated += flt(row.allocated_amount);
+			}
+		});
+
+		const paid_amount = flt(frm.doc.paid_amount);
+		const refund_amount = flt(paid_amount - total_allocated, 0);
+
+		if (refund_amount > 0) {
+			if (flt(frm.doc.refund_amount, 0) === refund_amount) {
+				return;
+			}
+
+			frm.events.show_refund_confirmation_dialog(frm, refund_amount, total_allocated);
+			frappe.validated = false;
+			return;
+		}
+
+		if (flt(frm.doc.refund_amount) > 0) {
+			frm.set_value("refund_amount", 0);
+		}
+	},
+
+	show_refund_confirmation_dialog: function (frm, refund_amount, total_allocated) {
+		const message = __(
+			"<b>Cảnh báo: Số tiền phân bổ nhỏ hơn số tiền thanh toán</b><br><br>" +
+			"- <b>Số tiền thanh toán:</b> {0}<br>" +
+			"- <b>Đã phân bổ:</b> {1}<br>" +
+			"- <b>Tiền hoàn (dự kiến): {2}</b><br><br>",
+			[
+				format_currency(frm.doc.paid_amount, frm.doc.paid_from_account_currency, 0),
+				format_currency(total_allocated, frm.doc.paid_from_account_currency, 0),
+				format_currency(refund_amount, frm.doc.paid_from_account_currency, 0)
+			]
+		);
+
+		frappe.confirm(
+			message,
+			function() {
+				frm.set_value("refund_amount", refund_amount).then(() => {
+					frappe.show_alert({
+						message: __(
+							"Đã xác nhận hoàn tiền: {0}",
+							[format_currency(refund_amount, frm.doc.paid_from_account_currency, 0)]
+						),
+						indicator: "green"
+					}, 10);
+					frm.save();
+				});
+			},
+			function() { frm.set_value("refund_amount", 0); },
+			{ dialog_title: "Thông báo", confirm_title: "Xác nhận", reject_title: "Phân bổ lại" }
+		);
 	},
 
 	set_unallocated_amount: function (frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -60,6 +60,7 @@
   "source_exchange_rate",
   "base_paid_amount",
   "base_paid_amount_after_tax",
+  "refund_amount",
   "column_break_21",
   "paid_amount",
   "received_amount",
@@ -994,6 +995,12 @@
    "label": "Admin Editing",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "refund_amount",
+   "fieldtype": "Currency",
+   "label": "Refund amount",
+   "precision": "0"
   }
  ],
  "grid_page_length": 50,
@@ -1008,7 +1015,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2026-01-29 17:49:27.048607",
+ "modified": "2026-04-14 10:51:09.637174",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -222,6 +222,7 @@ class PaymentEntry(AccountsController):
 		self.validate_mandatory()
 		self.validate_reference_documents()
 		self.set_amounts()
+		self.set_refund_amount()
 		self.validate_amounts()
 		self.apply_taxes()
 		self.set_amounts_after_tax()
@@ -2236,6 +2237,18 @@ class PaymentEntry(AccountsController):
 	def set_payment_code(self):
 		if self.mode_of_payment:
 			self.payment_code = self.get_payment_code()
+
+	def set_refund_amount(self):
+		if not self.references:
+			return
+
+		total_allocated = sum(flt(d.allocated_amount) for d in self.references)
+
+		if self.paid_amount > total_allocated:
+			self.refund_amount = flt(self.paid_amount - total_allocated, self.precision("refund_amount"))
+			return
+
+		self.refund_amount = 0
 
 	@frappe.whitelist()
 	def verify_payment(self):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -133,7 +133,7 @@ class PaymentEntry(AccountsController):
 		party_name: DF.Data | None
 		party_type: DF.Link | None
 		payment_code: DF.Data | None
-		payment_date: DF.Datetime
+		payment_date: DF.Datetime | None
 		payment_order: DF.Link | None
 		payment_order_status: DF.Literal["Pending", "Success", "Cancel"]
 		payment_type: DF.Literal["Receive", "Pay", "Internal Transfer"]
@@ -148,6 +148,7 @@ class PaymentEntry(AccountsController):
 		reference_date: DF.Date | None
 		reference_no: DF.Data | None
 		references: DF.Table[PaymentEntryReference]
+		refund_amount: DF.Currency | None
 		remarks: DF.SmallText | None
 		sales_taxes_and_charges_template: DF.Link | None
 		shipping_code: DF.Data | None

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -11,6 +11,7 @@
   "split_order_group_name",
   "paid_amount",
   "allocated_amount",
+  "unallocated_amount",
   "balance",
   "mode_of_payment",
   "gateway",
@@ -269,6 +270,13 @@
    "fieldname": "ref_order_date",
    "fieldtype": "Date",
    "label": "Ref Order Date"
+  },
+  {
+   "fieldname": "unallocated_amount",
+   "fieldtype": "Currency",
+   "label": "Unallocated",
+   "precision": "0",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import flt
 
 
 class PaymentEntryReference(Document):
@@ -27,6 +28,7 @@ class PaymentEntryReference(Document):
 		exchange_gain_loss: DF.Currency
 		exchange_rate: DF.Float
 		gateway: DF.Data | None
+		unallocated_amount: DF.Currency
 		mode_of_payment: DF.Link | None
 		order_number: DF.Data | None
 		outstanding_amount: DF.Float
@@ -55,3 +57,11 @@ class PaymentEntryReference(Document):
 			return
 
 		return frappe.db.get_value("Payment Request", self.payment_request, "outstanding_amount")
+
+	def before_save(self):
+		# Auto-calculate unallocated_amount
+		if self.paid_amount and self.allocated_amount:
+			diff = flt(self.paid_amount - self.allocated_amount)
+			self.unallocated_amount = diff if diff > 0 else 0
+		else:
+			self.unallocated_amount = 0

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -279,7 +279,7 @@ class SalesOrder(SellingController):
 		payment_references = frappe.db.sql("""
 			SELECT
 				pr.name, pr.parenttype, pr.parent, pr.reference_doctype, pr.reference_name,
-				pr.total_amount, pr.outstanding_amount, pr.order_number, pr.split_order_group_name,
+				pr.total_amount, pr.outstanding_amount, pr.unallocated_amount, pr.order_number, pr.split_order_group_name,
 				pr.bank_account, pr.bank, pr.bank_account_no, pr.bank_account_branch, pr.ref_order_number, pr.ref_order_date,
 				CASE
 					WHEN pe.payment_type = 'Pay' THEN -pr.allocated_amount
@@ -309,6 +309,7 @@ class SalesOrder(SellingController):
 					"reference_name": pe_ref.parent,
 					"total_amount": pe_ref.total_amount,
 					"outstanding_amount": pe_ref.outstanding_amount,
+					"unallocated_amount": pe_ref.unallocated_amount,
 					"allocated_amount": pe_ref.allocated_amount,
 					"parent": pe_ref.reference_name,
 					"parentfield": "payment_entries",
@@ -347,7 +348,7 @@ class SalesOrder(SellingController):
 		payment_references = frappe.db.sql("""
 			SELECT
 				pr.name, pr.parenttype, pr.parent, pr.reference_doctype, pr.reference_name,
-				pr.total_amount, pr.outstanding_amount, pr.order_number, pr.split_order_group_name,
+				pr.total_amount, pr.outstanding_amount, pr.unallocated_amount, pr.order_number, pr.split_order_group_name,
 				pr.bank_account, pr.bank, pr.bank_account_no, pr.bank_account_branch, pr.ref_order_number, pr.ref_order_date,
 				CASE
 					WHEN pe.payment_type = 'Pay' THEN -pr.allocated_amount
@@ -376,6 +377,7 @@ class SalesOrder(SellingController):
 						"reference_name": pe_ref.parent,
 						"total_amount": pe_ref.total_amount,
 						"outstanding_amount": pe_ref.outstanding_amount,
+						"unallocated_amount": pe_ref.unallocated_amount,
 						"allocated_amount": pe_ref.allocated_amount,
 						"parent": pe_ref.reference_name,
 						"parentfield": "group_payment_entries",


### PR DESCRIPTION
#### Changes
- Added refund_amount field to Payment Entry
- Update Sales Order allocated amount logic
  - If the total allocated amount from all order is smaller than PE's paid_amount ,we will display the dialog for user to choosing ( refer to image below)
  
  
  
<img width="1042" height="542" alt="image" src="https://github.com/user-attachments/assets/27bba03e-bdc0-44de-b787-f949fe48b4fb" />
