### PR TITLE
chore: temporary not using frappe validate when allocate

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -233,7 +233,7 @@ class PaymentEntry(AccountsController):
 		self.set_remarks()
 		self.validate_duplicate_entry()
 		self.validate_payment_type_with_outstanding()
-		self.validate_allocated_amount()
+		# self.validate_allocated_amount()
 		self.validate_paid_invoices()
 		self.ensure_supplier_is_not_blocked()
 		self.set_tax_withholding()


### PR DESCRIPTION
#### Changes
- Temporary turn off refereces allocated_amount with outstanding_amoun validation