### PR TITLE
fix(sales-order): remove linked payment entry if SO is cancelled

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -4365,6 +4365,10 @@ def sync_so_snapshot_pe_fields_background(pe_name):
 		})
 
 		for so_name in so_names:
+			cancelled_status = frappe.db.get_value("Sales Order", so_name, "cancelled_status")
+			if cancelled_status == "Cancelled":
+				continue
+			
 			so = frappe.get_doc("Sales Order", so_name)
 			so.set_payment_entries()
 			so.set_group_payment_entries()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -301,6 +301,21 @@ class SalesOrder(SellingController):
 		if self.docstatus == 2 or not self.name:
 			return
 
+		if self.cancelled_status == "Cancelled":
+			self.set("payment_entries", [])
+			frappe.db.sql("""
+				DELETE FROM `tabPayment Entry Reference`
+				WHERE parent = %s AND parentfield = 'payment_entries' AND parenttype = 'Sales Order'
+			""", self.name)
+
+			frappe.db.sql("""
+				UPDATE `tabSales Order`
+				SET modified = %s
+				WHERE name = %s
+			""", (frappe.utils.now(), self.name))
+			frappe.db.commit()
+			return
+
 		self.set("payment_entries", [])
 
 		# Get payment entries linked to this sales order
@@ -913,6 +928,7 @@ class SalesOrder(SellingController):
 		self.check_status_changes_for_rank()
 		self.sync_tracking_number_to_payment_entry()
 		self.copy_from_reference_order()
+		self.set_payment_entries()
 
 	def sync_tracking_number_to_payment_entry(self):
 		if not self.tracking_number:


### PR DESCRIPTION
#### Changes
- If the sales order is cancelled, we removed linked PE in it child table `payment_entries`
- The linked Payment Entry on save will not sync to Sales Order's payment_entries back if sales order is cancelled

- Task: [Link](https://applink.larksuite.com/client/todo/detail?guid=e2ba3760-3302-4052-954b-45f57d626ef8&suite_entity_num=t119911)