### PR TITLE
Chore/sales order debt/temporary hid two new field

### DIFF
--- a/erpnext/selling/doctype/order_and_debt_tracking/order_and_debt_tracking.json
+++ b/erpnext/selling/doctype/order_and_debt_tracking/order_and_debt_tracking.json
@@ -54,12 +54,14 @@
   {
    "fieldname": "progress_status",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Progress Statuss",
    "options": "\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch s\u1ebd nh\u1eadn tu\u1ea7n t\u1edbi\n\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch ch\u01b0a ch\u1ed1t ng\u00e0y nh\u1eadn\nCh\u01b0a \u0111\u1ee7 h\u00e0ng\n\u0110\u00e3 giao \u2013 ch\u01b0a thu \u0111\u1ee7 ti\u1ec1n"
   },
   {
    "fieldname": "status_reason",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Progress Status Specify",
    "options": "Kh\u00e1ch \u0111\u00e3 ch\u1ed1t ng\u00e0y \u0111\u1ebfn nh\u1eadn t\u1ea1i c\u1eeda h\u00e0ng\nSale s\u1ebd giao t\u1eadn n\u01a1i cho kh\u00e1ch\nG\u1eedi \u0111\u01a1n v\u1ecb v\u1eadn chuy\u1ec3n (COD) v\u1ec1 \u0111\u1ecba ch\u1ec9 kh\u00e1ch\nKh\u00e1ch ch\u01b0a h\u1eb9n ng\u00e0y nh\u1eadn c\u1ee5 th\u1ec3, sale \u0111ang care th\u00eam\nKh\u00e1ch b\u1eadn (c\u00f4ng t\u00e1c, n\u01b0\u1edbc ngo\u00e0i, du l\u1ecbch...)\nKh\u00e1ch ch\u01b0a \u0111\u1ee7 ti\u1ec1n / \u0111ang gom ti\u1ec1n\n\u0110\u01a1n qu\u00e1 h\u1ea1n c\u00f4ng n\u1ee3, \u0111\u00e3 l\u00e0m \u0111\u1ec1 xu\u1ea5t gia h\u1ea1n\n\u0110ang gia c\u00f4ng\n\u0110\u1ee3i qu\u00e0 t\u1eb7ng\nKh\u00e1ch ch\u1edd nh\u1eadn c\u00f9ng c\u00e1c \u0111\u01a1n kh\u00e1c\nH\u00e0ng l\u1ed7i, \u0111ang b\u1ea3o h\u00e0nh t\u1ea1i x\u01b0\u1edfng\n\u0110\u00e3 giao h\u00e0ng nh\u01b0ng ch\u01b0a thanh to\u00e1n \u0111\u1ee7 (qu\u1ea3n l\u00fd \u0111\u00e3 duy\u1ec7t)"
   },
@@ -85,7 +87,7 @@
  "is_submittable": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-03 13:48:37.986295",
+ "modified": "2026-06-04 10:00:18.511380",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Order and Debt Tracking",

--- a/erpnext/selling/doctype/order_and_debt_tracking/order_and_debt_tracking.py
+++ b/erpnext/selling/doctype/order_and_debt_tracking/order_and_debt_tracking.py
@@ -25,9 +25,9 @@ class OrderandDebtTracking(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		progress_status: DF.Literal["", "\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch s\u1ebd nh\u1eadn tu\u1ea7n t\u1edbi", "\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch ch\u01b0a ch\u1ed1t ng\u00e0y nh\u1eadn", "Ch\u01b0a \u0111\u1ee7 h\u00e0ng", "\u0110\u00e3 giao \u2013 ch\u01b0a thu \u0111\u1ee7 ti\u1ec1n"]
+		progress_status: DF.Literal["\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch s\u1ebd nh\u1eadn tu\u1ea7n t\u1edbi", "\u0110\u1ee7 h\u00e0ng \u2013 kh\u00e1ch ch\u01b0a ch\u1ed1t ng\u00e0y nh\u1eadn", "Ch\u01b0a \u0111\u1ee7 h\u00e0ng", "\u0110\u00e3 giao \u2013 ch\u01b0a thu \u0111\u1ee7 ti\u1ec1n"]
 		status: DF.Literal["", "Waiting for Customer Pickup", "Waiting for Product", "Delayed / Postponed"]
-		status_reason: DF.Literal["", "Kh\u00e1ch \u0111\u00e3 ch\u1ed1t ng\u00e0y \u0111\u1ebfn nh\u1eadn t\u1ea1i c\u1eeda h\u00e0ng", "Sale s\u1ebd giao t\u1eadn n\u01a1i cho kh\u00e1ch", "G\u1eedi \u0111\u01a1n v\u1ecb v\u1eadn chuy\u1ec3n (COD) v\u1ec1 \u0111\u1ecba ch\u1ec9 kh\u00e1ch", "Kh\u00e1ch ch\u01b0a h\u1eb9n ng\u00e0y nh\u1eadn c\u1ee5 th\u1ec3, sale \u0111ang care th\u00eam", "Kh\u00e1ch b\u1eadn (c\u00f4ng t\u00e1c, n\u01b0\u1edbc ngo\u00e0i, du l\u1ecbch...)", "Kh\u00e1ch ch\u01b0a \u0111\u1ee7 ti\u1ec1n / \u0111ang gom ti\u1ec1n", "\u0110\u01a1n qu\u00e1 h\u1ea1n c\u00f4ng n\u1ee3, \u0111\u00e3 l\u00e0m \u0111\u1ec1 xu\u1ea5t gia h\u1ea1n", "\u0110ang gia c\u00f4ng", "\u0110\u1ee3i qu\u00e0 t\u1eb7ng", "Kh\u00e1ch ch\u1edd nh\u1eadn c\u00f9ng c\u00e1c \u0111\u01a1n kh\u00e1c", "H\u00e0ng l\u1ed7i, \u0111ang b\u1ea3o h\u00e0nh t\u1ea1i x\u01b0\u1edfng", "\u0110\u00e3 giao h\u00e0ng nh\u01b0ng ch\u01b0a thanh to\u00e1n \u0111\u1ee7 (qu\u1ea3n l\u00fd \u0111\u00e3 duy\u1ec7t)"]
+		status_reason: DF.Literal["Kh\u00e1ch \u0111\u00e3 ch\u1ed1t ng\u00e0y \u0111\u1ebfn nh\u1eadn t\u1ea1i c\u1eeda h\u00e0ng", "Sale s\u1ebd giao t\u1eadn n\u01a1i cho kh\u00e1ch", "G\u1eedi \u0111\u01a1n v\u1ecb v\u1eadn chuy\u1ec3n (COD) v\u1ec1 \u0111\u1ecba ch\u1ec9 kh\u00e1ch", "Kh\u00e1ch ch\u01b0a h\u1eb9n ng\u00e0y nh\u1eadn c\u1ee5 th\u1ec3, sale \u0111ang care th\u00eam", "Kh\u00e1ch b\u1eadn (c\u00f4ng t\u00e1c, n\u01b0\u1edbc ngo\u00e0i, du l\u1ecbch...)", "Kh\u00e1ch ch\u01b0a \u0111\u1ee7 ti\u1ec1n / \u0111ang gom ti\u1ec1n", "\u0110\u01a1n qu\u00e1 h\u1ea1n c\u00f4ng n\u1ee3, \u0111\u00e3 l\u00e0m \u0111\u1ec1 xu\u1ea5t gia h\u1ea1n", "\u0110ang gia c\u00f4ng", "\u0110\u1ee3i qu\u00e0 t\u1eb7ng", "Kh\u00e1ch ch\u1edd nh\u1eadn c\u00f9ng c\u00e1c \u0111\u01a1n kh\u00e1c", "H\u00e0ng l\u1ed7i, \u0111ang b\u1ea3o h\u00e0nh t\u1ea1i x\u01b0\u1edfng", "\u0110\u00e3 giao h\u00e0ng nh\u01b0ng ch\u01b0a thanh to\u00e1n \u0111\u1ee7 (qu\u1ea3n l\u00fd \u0111\u00e3 duy\u1ec7t)"]
 	# end: auto-generated types
 
 	def before_save(self):
@@ -45,7 +45,7 @@ class OrderandDebtTracking(Document):
 	def _notify_assigned_user(self):
 		if not self.notify_to:
 			return
-		
+
 		user_info = frappe.db.get_value("User", self.notify_to, ["email", "enabled", "language"], as_dict=True)
 		if not user_info or not user_info.enabled:
 			return

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -2360,6 +2360,7 @@
    "description": "Total Buyback Item - Balance (Group )",
    "fieldname": "total_group_balance",
    "fieldtype": "Currency",
+   "hidden": 1,
    "label": "Total Group Balance",
    "options": "currency",
    "read_only": 1
@@ -2370,7 +2371,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-29 16:59:15.353434",
+ "modified": "2026-06-04 10:03:34.006083",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -61,22 +61,31 @@ class SalesOrder(SellingController):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.types import DF
+
 		from erpnext.accounts.doctype.item_wise_tax_detail.item_wise_tax_detail import ItemWiseTaxDetail
 		from erpnext.accounts.doctype.payment_entry_reference.payment_entry_reference import PaymentEntryReference
 		from erpnext.accounts.doctype.payment_schedule.payment_schedule import PaymentSchedule
 		from erpnext.accounts.doctype.pricing_rule_detail.pricing_rule_detail import PricingRuleDetail
-		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import SalesTaxesandCharges
-		from erpnext.selling.doctype.order_and_debt_tracking.order_and_debt_tracking import OrderandDebtTracking
+		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import (
+			SalesTaxesandCharges,
+		)
+		from erpnext.selling.doctype.order_and_debt_tracking.order_and_debt_tracking import (
+			OrderandDebtTracking,
+		)
 		from erpnext.selling.doctype.sales_order_item.sales_order_item import SalesOrderItem
-		from erpnext.selling.doctype.sales_order_payment_record.sales_order_payment_record import SalesOrderPaymentRecord
+		from erpnext.selling.doctype.sales_order_payment_record.sales_order_payment_record import (
+			SalesOrderPaymentRecord,
+		)
 		from erpnext.selling.doctype.sales_order_policy.sales_order_policy import SalesOrderPolicy
-		from erpnext.selling.doctype.sales_order_product_category.sales_order_product_category import SalesOrderProductCategory
+		from erpnext.selling.doctype.sales_order_product_category.sales_order_product_category import (
+			SalesOrderProductCategory,
+		)
 		from erpnext.selling.doctype.sales_order_promotion.sales_order_promotion import SalesOrderPromotion
 		from erpnext.selling.doctype.sales_order_purpose.sales_order_purpose import SalesOrderPurpose
 		from erpnext.selling.doctype.sales_order_reference.sales_order_reference import SalesOrderReference
 		from erpnext.selling.doctype.sales_team.sales_team import SalesTeam
 		from erpnext.stock.doctype.packed_item.packed_item import PackedItem
-		from frappe.types import DF
 
 		additional_discount_percentage: DF.Float
 		address_display: DF.TextEditor | None

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -61,31 +61,22 @@ class SalesOrder(SellingController):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from erpnext.accounts.doctype.item_wise_tax_detail.item_wise_tax_detail import ItemWiseTaxDetail
 		from erpnext.accounts.doctype.payment_entry_reference.payment_entry_reference import PaymentEntryReference
 		from erpnext.accounts.doctype.payment_schedule.payment_schedule import PaymentSchedule
 		from erpnext.accounts.doctype.pricing_rule_detail.pricing_rule_detail import PricingRuleDetail
-		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import (
-			SalesTaxesandCharges,
-		)
-		from erpnext.selling.doctype.order_and_debt_tracking.order_and_debt_tracking import (
-			OrderandDebtTracking,
-		)
+		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import SalesTaxesandCharges
+		from erpnext.selling.doctype.order_and_debt_tracking.order_and_debt_tracking import OrderandDebtTracking
 		from erpnext.selling.doctype.sales_order_item.sales_order_item import SalesOrderItem
-		from erpnext.selling.doctype.sales_order_payment_record.sales_order_payment_record import (
-			SalesOrderPaymentRecord,
-		)
+		from erpnext.selling.doctype.sales_order_payment_record.sales_order_payment_record import SalesOrderPaymentRecord
 		from erpnext.selling.doctype.sales_order_policy.sales_order_policy import SalesOrderPolicy
-		from erpnext.selling.doctype.sales_order_product_category.sales_order_product_category import (
-			SalesOrderProductCategory,
-		)
+		from erpnext.selling.doctype.sales_order_product_category.sales_order_product_category import SalesOrderProductCategory
 		from erpnext.selling.doctype.sales_order_promotion.sales_order_promotion import SalesOrderPromotion
 		from erpnext.selling.doctype.sales_order_purpose.sales_order_purpose import SalesOrderPurpose
 		from erpnext.selling.doctype.sales_order_reference.sales_order_reference import SalesOrderReference
 		from erpnext.selling.doctype.sales_team.sales_team import SalesTeam
 		from erpnext.stock.doctype.packed_item.packed_item import PackedItem
+		from frappe.types import DF
 
 		additional_discount_percentage: DF.Float
 		address_display: DF.TextEditor | None


### PR DESCRIPTION
#### Changes
- Order and Debt tracking: hidden `progress_status` and `status_reason` in the UI
- Sales Order: hidden `total_group_balance` in the UI